### PR TITLE
fix: 讓 multi_resolution_hls.sh 的 playlist 重寫邏輯相容 Linux

### DIFF
--- a/script/multi_resolution_hls.sh
+++ b/script/multi_resolution_hls.sh
@@ -97,6 +97,14 @@ echo "改名中..."
 
 # 修復檔名：將 playlist 與 segment 重新命名為要求的格式
 
+replace_in_file() {
+    local expression=$1
+    local file_path=$2
+    local temp_file="${file_path}.tmp"
+
+    sed -E "$expression" "$file_path" > "$temp_file" && mv "$temp_file" "$file_path"
+}
+
 # 遍歷剛產出的資料夾
 for dir in "${BASENAME}"/*/; do
     dir=${dir%/} # 去掉結尾斜線
@@ -120,12 +128,12 @@ for dir in "${BASENAME}"/*/; do
 
     # 同步更新 variant playlist 內的 segment 路徑引用。
     if [ -f "$variant_playlist" ]; then
-        sed -E -i '' "s|segment_([0-9]+)\.ts|segment_${folder_name}_\\1.ts|g" "$variant_playlist"
+        replace_in_file "s|segment_([0-9]+)\.ts|segment_${folder_name}_\\1.ts|g" "$variant_playlist"
     fi
 done
 
 # 同步修正 index.m3u8 (Master Playlist) 裡面的路徑引用
 # 只替換同一路徑下的 temp.m3u8，避免所有畫質都被改成相同檔名。
-sed -E -i '' 's|([^/]+)/temp\.m3u8|\1/streaminglist-\1.m3u8|g' "${BASENAME}/index.m3u8"
+replace_in_file 's|([^/]+)/temp\.m3u8|\1/streaminglist-\1.m3u8|g' "${BASENAME}/index.m3u8"
 
 echo "🎉 轉檔與資料夾建置完成！"


### PR DESCRIPTION
## 問題
GitHub Actions 在 Ubuntu 上執行 `npm test` 時失敗，因為 `script/multi_resolution_hls.sh` 仍然保留了 `temp.m3u8` 與沒有解析度前綴的 segment 檔名，導致 `script/multi_resolution_hls.spec.js` 有 4 個測試失敗。

## 根因
這支 script 使用了 BSD/macOS 專用的 `sed -E -i ''` 原地改檔寫法。這個寫法在 GNU/Linux runner 上行為不同，因此 CI 裡的 playlist 內容沒有被正確改寫。

## 修改內容
- 新增 `replace_in_file` 輔助函式，透過暫存檔加 `mv` 的方式重寫檔案
- 用這個 helper 更新 variant playlist，將 segment 路徑改為 `segment_<resolution>_<index>.ts`
- 用這個 helper 更新 master playlist，將路徑改為 `streaminglist-<resolution>.m3u8`

## 驗證
- `npm test -- script/multi_resolution_hls.spec.js`
- `npm test`
- `npm run build`
- `codex/ci-investigate` 的 GitHub Actions CI 已通過
