### PR TITLE
feature(player): gateway 切換時沿用 sidecar 快取並支援 sidecar fallback

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,6 @@ import WatchPage from './components/WatchPage.vue';
 import HistoryPage from './components/HistoryPage.vue';
 import RecommendationsPage from './components/RecommendationsPage.vue';
 import {
-  buildGatewayAssetUrl,
   defaultPublicGateway,
   getDefaultGateway,
   isLoopbackGatewayUrl,
@@ -14,18 +13,28 @@ import {
   persistGateway,
   readStoredGateway,
 } from './utils/gateway';
-import { createDefaultVideoInfo, fetchVideoInfo } from './utils/videoInfo';
+import { createDefaultVideoInfo } from './utils/videoInfo';
 import {
   createDefaultSubtitlePreference,
-  fetchSubtitleCatalog,
   mergeSubtitleTracks,
   persistSubtitlePreference,
   readStoredSubtitlePreference,
   reconcileSubtitlePreference,
-  resolveSubtitleTracks,
   revokeImportedSubtitleTracks,
   subtitleCatalogStatus,
 } from './utils/subtitles';
+import {
+  avatarAssetFileName,
+  buildSidecarGatewayCandidates,
+  loadAvatarUrlWithFallback,
+  loadPosterUrlWithFallback,
+  loadSubtitleCatalogWithFallback,
+  loadVideoInfoWithFallback,
+  posterAssetFileName,
+  readCachedSidecarObjectUrl,
+  readCachedSubtitleCatalog,
+  readCachedVideoInfo,
+} from './utils/sidecarAssets';
 import { parsePlayerParams } from './utils/url';
 import { getPlaybackSnapshot } from './utils/playback';
 import {
@@ -41,6 +50,8 @@ const status = ref('準備就緒');
 const currentM3u8Url = ref('');
 const currentIpfsBaseUrl = ref('');
 const currentPosterUrl = ref('');
+const currentHistoryPosterUrl = ref('');
+const currentAvatarUrl = ref('');
 const currentVideoInfo = ref(createDefaultVideoInfo());
 const currentRemoteSubtitleTracks = ref([]);
 const currentRemoteSubtitleStatus = ref(subtitleCatalogStatus.idle);
@@ -57,6 +68,7 @@ const currentLoadSequence = ref(0);
 const activeView = ref('home');
 const historyItems = ref([]);
 const isSidebarOpen = ref(false);
+const sidecarGatewayCandidates = ref([]);
 
 let originalPushState = null;
 let originalReplaceState = null;
@@ -68,6 +80,8 @@ function resetPlaybackState() {
   currentM3u8Url.value = '';
   currentIpfsBaseUrl.value = '';
   currentPosterUrl.value = '';
+  currentHistoryPosterUrl.value = '';
+  currentAvatarUrl.value = '';
   currentVideoInfo.value = createDefaultVideoInfo();
   clearImportedSubtitles();
   currentRemoteSubtitleTracks.value = [];
@@ -256,10 +270,29 @@ function onGatewayChange(gateway) {
   persistGateway(nextGateway, window);
 }
 
+function onGatewayCandidatesChange(payload = {}) {
+  sidecarGatewayCandidates.value = Array.isArray(payload?.candidates)
+    ? payload.candidates
+        .map((candidate) => (typeof candidate?.url === 'string' ? candidate.url.trim() : ''))
+        .filter((candidate) => candidate)
+    : [];
+}
+
+function resolveSidecarCandidates(primaryGateway) {
+  return buildSidecarGatewayCandidates(primaryGateway, sidecarGatewayCandidates.value);
+}
+
 function loadVideo(cid, gateway, startTime = 0, options = {}) {
   const { updateUrl = true, shouldAutoplay = false } = options;
   const nextGateway = resolveGateway(gateway || readConfiguredGateway());
   const requestSeq = ++metadataRequestSeq;
+  const nextIpfsBaseUrl = `${nextGateway}${cid}/`;
+  const nextM3u8Url = `${nextGateway}${cid}/index.m3u8`;
+  const historyPosterUrl = `${nextGateway}${cid}/${posterAssetFileName}`;
+  const cachedPosterUrl = readCachedSidecarObjectUrl(cid, posterAssetFileName);
+  const cachedAvatarUrl = readCachedSidecarObjectUrl(cid, avatarAssetFileName);
+  const cachedVideoInfo = readCachedVideoInfo(cid);
+  const cachedSubtitleCatalog = readCachedSubtitleCatalog(cid, nextGateway, sidecarGatewayCandidates.value);
 
   persistCurrentHistory();
   const shouldClearImportedSubtitles = currentCid.value && currentCid.value !== cid;
@@ -267,31 +300,29 @@ function loadVideo(cid, gateway, startTime = 0, options = {}) {
   currentGateway.value = nextGateway;
   currentLoadSequence.value += 1;
   persistGateway(nextGateway, window);
-
-  const ipfsBaseUrl = buildGatewayAssetUrl(nextGateway, cid);
-  const m3u8Url = buildGatewayAssetUrl(nextGateway, cid, 'index.m3u8');
-  const posterUrl = buildGatewayAssetUrl(nextGateway, cid, 'cover.webp');
   status.value = '正在連線至網關...';
   
-  currentIpfsBaseUrl.value = ipfsBaseUrl;
-  currentM3u8Url.value = m3u8Url;
-  currentPosterUrl.value = posterUrl;
-  currentVideoInfo.value = createDefaultVideoInfo();
+  currentIpfsBaseUrl.value = nextIpfsBaseUrl;
+  currentM3u8Url.value = nextM3u8Url;
+  currentPosterUrl.value = cachedPosterUrl;
+  currentHistoryPosterUrl.value = historyPosterUrl;
+  currentAvatarUrl.value = cachedAvatarUrl;
+  currentVideoInfo.value = cachedVideoInfo || createDefaultVideoInfo();
   if (shouldClearImportedSubtitles) {
     clearImportedSubtitles();
   }
-  currentRemoteSubtitleTracks.value = [];
-  currentRemoteSubtitleStatus.value = subtitleCatalogStatus.loading;
+  currentRemoteSubtitleTracks.value = cachedSubtitleCatalog?.tracks || [];
+  currentRemoteSubtitleStatus.value = cachedSubtitleCatalog?.status || subtitleCatalogStatus.loading;
   currentStartTime.value = startTime;
   currentShouldAutoplay.value = shouldAutoplay;
   persistHistoryEntry({
     cid,
-    posterUrl,
+    posterUrl: historyPosterUrl,
     gateway: nextGateway,
     progressSeconds: startTime,
     lastWatchedAt: Date.now(),
   });
-  void loadSidecarAssets(ipfsBaseUrl, requestSeq);
+  void loadSidecarAssets(cid, nextGateway, requestSeq);
 
   if (updateUrl) {
     syncPlayerUrl(cid, startTime, 'push');
@@ -361,23 +392,28 @@ function onSubtitleSelectionChange(nextSelection) {
   setSubtitleSelection(nextSelection);
 }
 
-async function loadSidecarAssets(ipfsBaseUrl, requestSeq) {
-  const [nextVideoInfo, subtitleCatalog] = await Promise.all([
-    fetchVideoInfo(ipfsBaseUrl).catch(() => createDefaultVideoInfo()),
-    fetchSubtitleCatalog(ipfsBaseUrl),
+async function loadSidecarAssets(cid, gateway, requestSeq) {
+  const sidecarCandidates = resolveSidecarCandidates(gateway);
+  const [nextPosterUrl, nextAvatarUrl, nextVideoInfo, subtitleCatalog] = await Promise.all([
+    loadPosterUrlWithFallback(cid, gateway, sidecarCandidates),
+    loadAvatarUrlWithFallback(cid, gateway, sidecarCandidates),
+    loadVideoInfoWithFallback(cid, gateway, sidecarCandidates),
+    loadSubtitleCatalogWithFallback(cid, gateway, sidecarCandidates),
   ]);
 
   if (requestSeq !== metadataRequestSeq) return;
 
+  currentPosterUrl.value = nextPosterUrl || currentPosterUrl.value;
+  currentAvatarUrl.value = nextAvatarUrl || '';
   currentVideoInfo.value = nextVideoInfo;
   currentRemoteSubtitleStatus.value = subtitleCatalog.status;
-  currentRemoteSubtitleTracks.value = resolveSubtitleTracks(ipfsBaseUrl, subtitleCatalog.tracks);
+  currentRemoteSubtitleTracks.value = subtitleCatalog.tracks;
   const snapshot = activeView.value === 'home' ? getPlaybackSnapshot(window) : null;
   persistHistoryEntry({
     cid: currentCid.value,
     title: nextVideoInfo.title,
     uploader: nextVideoInfo.uploader,
-    posterUrl: currentPosterUrl.value,
+    posterUrl: currentHistoryPosterUrl.value,
     gateway: currentGateway.value,
     durationString: nextVideoInfo.durationString,
     durationSeconds: snapshot?.duration ?? 0,
@@ -436,7 +472,7 @@ function persistCurrentHistory(options = {}) {
     cid,
     title: currentVideoInfo.value.title,
     uploader: currentVideoInfo.value.uploader,
-    posterUrl: currentPosterUrl.value,
+    posterUrl: currentHistoryPosterUrl.value,
     gateway: currentGateway.value,
     durationString: currentVideoInfo.value.durationString,
     durationSeconds: currentSnapshot.duration,
@@ -547,6 +583,7 @@ watch(
     :current-load-sequence="currentLoadSequence"
     :sidebar-open="isSidebarOpen"
     @gateway-change="onGatewayChange"
+    @gateway-candidates-change="onGatewayCandidatesChange"
     @toggle-sidebar="toggleSidebar"
   />
   <div class="app-container">
@@ -575,6 +612,7 @@ watch(
           :ipfs-base-url="currentIpfsBaseUrl"
           :m3u8-url="currentM3u8Url"
           :poster-url="currentPosterUrl"
+          :avatar-url="currentAvatarUrl"
           :subtitles="currentSubtitleTracks"
           :subtitle-selection="currentSubtitleSelection"
           :remote-subtitle-status="currentRemoteSubtitleStatus"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -31,7 +31,7 @@ const props = defineProps({
   currentLoadSequence: { type: Number, default: 0 },
   sidebarOpen: { type: Boolean, default: false },
 });
-const emit = defineEmits(['search', 'gateway-change', 'toggle-sidebar']);
+const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar']);
 const { availableLocales, locale, setLocale, t } = useI18n();
 
 const searchQuery = ref('');
@@ -79,6 +79,45 @@ const orderedBuiltInGateways = computed(() =>
     return (builtInGatewayOrder[left.id] ?? 0) - (builtInGatewayOrder[right.id] ?? 0);
   })
 );
+const orderedGatewayCandidates = computed(() => {
+  const candidates = builtInGateways.map((gateway) => ({
+    id: gateway.id,
+    url: gatewayUrl(gateway),
+    order: builtInGatewayOrder[gateway.id] ?? 0,
+    probeState: probeStateFor(gateway.id),
+  }));
+
+  if (customGatewayPreview.value) {
+    candidates.push({
+      id: CUSTOM_GATEWAY_ID,
+      url: customGatewayPreview.value,
+      order: Number.MAX_SAFE_INTEGER,
+      probeState: probeStateFor(CUSTOM_GATEWAY_ID),
+    });
+  }
+
+  return candidates.sort((left, right) => {
+    const rankDiff = probeSortRank(left.probeState) - probeSortRank(right.probeState);
+    if (rankDiff !== 0) {
+      return rankDiff;
+    }
+
+    const performanceDiff = compareProbePerformance(left.probeState, right.probeState);
+    if (performanceDiff !== 0) {
+      return performanceDiff;
+    }
+
+    return left.order - right.order;
+  });
+});
+const gatewayCandidatesPayload = computed(() => ({
+  cid: currentCidValue.value,
+  candidates: orderedGatewayCandidates.value.map((candidate) => ({
+    id: candidate.id,
+    url: candidate.url,
+    state: candidate.probeState.state,
+  })),
+}));
 const recommendedGatewayId = computed(() => {
   const candidates = [
     ...builtInGateways.map((gateway) => ({
@@ -274,6 +313,14 @@ watch(settingsOpen, async (isOpen) => {
     nextFocusTarget.focus();
   }
 });
+
+watch(
+  gatewayCandidatesPayload,
+  (payload) => {
+    emit('gateway-candidates-change', payload);
+  },
+  { immediate: true, deep: true }
+);
 
 watch(
   () => [currentCidValue.value, props.currentLoadSequence],

--- a/src/components/VideoInfo.vue
+++ b/src/components/VideoInfo.vue
@@ -19,6 +19,7 @@ const defaultTags = ['IPFS', 'Web3', 'Decentralized'];
 
 const props = defineProps({
   cid: { type: String, default: '' },
+  avatarUrl: { type: String, default: '' },
   ipfsBaseUrl: { type: String, default: '' },
   subtitles: {
     type: Array,
@@ -112,7 +113,7 @@ const avatarUrl = computed(() => {
     return fallbackAvatarUrl.value;
   }
 
-  return buildSidecarAssetUrl(props.ipfsBaseUrl, 'avatar.jpg') || fallbackAvatarUrl.value;
+  return props.avatarUrl || fallbackAvatarUrl.value;
 });
 const displayUploadDateTooltip = computed(() => formatUploadDateTooltip(props.videoInfo.uploadDate));
 const displayRelativeUploadTime = computed(() => {
@@ -171,7 +172,7 @@ const collapsedDescriptionSegments = computed(() => linkifyDescription(collapsed
 let descriptionMeasureSeq = 0;
 
 watch(
-  () => [props.cid, props.ipfsBaseUrl],
+  () => [props.cid, props.ipfsBaseUrl, props.avatarUrl],
   () => {
     avatarLoadFailed.value = false;
     isDescriptionExpanded.value = false;

--- a/src/components/WatchPage.vue
+++ b/src/components/WatchPage.vue
@@ -24,6 +24,10 @@ defineProps({
     type: String,
     default: '',
   },
+  avatarUrl: {
+    type: String,
+    default: '',
+  },
   subtitles: {
     type: Array,
     default: () => [],
@@ -125,6 +129,7 @@ function handleSubtitleSelectionChange(nextSelection) {
     <h1 v-if="videoInfo.title" class="player-title">{{ videoInfo.title }}</h1>
     <VideoInfo
       :cid="cid"
+      :avatar-url="avatarUrl"
       :ipfs-base-url="ipfsBaseUrl"
       :subtitles="subtitles"
       :subtitle-selection="subtitleSelection"

--- a/src/components/header_search_actions.spec.js
+++ b/src/components/header_search_actions.spec.js
@@ -87,7 +87,7 @@ describe('Sidebar toggle contract', () => {
     expect(appTemplate).toContain('<Sidebar :active-view="activeView" :open="isSidebarOpen" @view-select="onViewSelect" />');
 
     expect(headerScript).toContain("sidebarOpen: { type: Boolean, default: false },");
-    expect(headerScript).toContain("const emit = defineEmits(['search', 'gateway-change', 'toggle-sidebar']);");
+    expect(headerScript).toContain("const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar']);");
     expect(headerScript).toContain('function toggleSidebar() {');
     expect(headerTemplate).toContain('aria-controls="app-sidebar"');
     expect(headerTemplate).toContain('data-testid="header-sidebar-toggle"');

--- a/src/components/video_layout.spec.js
+++ b/src/components/video_layout.spec.js
@@ -56,6 +56,7 @@ describe('WatchPage layout contract', () => {
     expect(template).toContain('class="player-container glass-panel"');
     expect(template).toContain('data-testid="player-container"');
     expect(template).toContain(':frame-rate="videoInfo.fps"');
+    expect(template).toContain(':avatar-url="avatarUrl"');
     expect(playerContainerIndex).toBeGreaterThan(-1);
     expect(playerTitleIndex).toBeGreaterThan(playerContainerIndex);
     expect(videoInfoIndex).toBeGreaterThan(playerTitleIndex);

--- a/src/utils/sidecarAssets.js
+++ b/src/utils/sidecarAssets.js
@@ -1,0 +1,408 @@
+import { buildGatewayAssetUrl, publicGatewayOptions } from './gateway';
+import { normalizeSubtitleManifest, subtitleCatalogStatus } from './subtitles';
+import { createDefaultVideoInfo, normalizeVideoInfo } from './videoInfo';
+
+export const posterAssetFileName = 'cover.webp';
+export const avatarAssetFileName = 'avatar.jpg';
+const videoInfoAssetFileName = 'info.json';
+const htmlContentTypePattern = /\btext\/html\b/i;
+const sidecarBlobCache = new Map();
+const sidecarVideoInfoCache = new Map();
+const sidecarSubtitleManifestCache = new Map();
+const inflightSidecarRequests = new Map();
+
+export function buildSidecarGatewayCandidates(primaryGateway = '', candidateGateways = []) {
+  const orderedCandidates = [];
+  const seen = new Set();
+
+  [primaryGateway, ...candidateGateways, ...publicGatewayOptions.map((gateway) => gateway.url)].forEach((gateway) => {
+    const normalizedGateway = normalizeString(gateway);
+    if (!normalizedGateway || seen.has(normalizedGateway)) {
+      return;
+    }
+
+    seen.add(normalizedGateway);
+    orderedCandidates.push(normalizedGateway);
+  });
+
+  return orderedCandidates;
+}
+
+export function readCachedSidecarObjectUrl(cid, assetPath) {
+  return sidecarBlobCache.get(createSidecarCacheKey(cid, assetPath))?.objectUrl || '';
+}
+
+export function readCachedVideoInfo(cid) {
+  const cachedValue = sidecarVideoInfoCache.get(createVideoInfoCacheKey(cid));
+  return cachedValue ? { ...cachedValue } : null;
+}
+
+export function readCachedSubtitleCatalog(cid, primaryGateway = '', candidateGateways = []) {
+  const cacheKey = createSubtitleManifestCacheKey(cid);
+  const cachedManifest = sidecarSubtitleManifestCache.get(cacheKey);
+
+  if (!cachedManifest) {
+    return null;
+  }
+
+  return {
+    status: cachedManifest.status,
+    tracks: buildResolvedSubtitleTracks(cachedManifest, cid, primaryGateway, candidateGateways),
+  };
+}
+
+export async function loadPosterUrlWithFallback(cid, primaryGateway = '', candidateGateways = [], options = {}) {
+  return loadBlobSidecarUrlWithFallback(cid, posterAssetFileName, primaryGateway, candidateGateways, options);
+}
+
+export async function loadAvatarUrlWithFallback(cid, primaryGateway = '', candidateGateways = [], options = {}) {
+  return loadBlobSidecarUrlWithFallback(cid, avatarAssetFileName, primaryGateway, candidateGateways, options);
+}
+
+export async function loadVideoInfoWithFallback(cid, primaryGateway = '', candidateGateways = [], options = {}) {
+  const normalizedCid = normalizeString(cid);
+  if (!normalizedCid) {
+    return createDefaultVideoInfo();
+  }
+
+  const cacheKey = createVideoInfoCacheKey(normalizedCid);
+  const cachedValue = sidecarVideoInfoCache.get(cacheKey);
+  if (cachedValue) {
+    return { ...cachedValue };
+  }
+
+  return runSidecarRequest(`info:${normalizedCid}`, async () => {
+    const gateways = buildSidecarGatewayCandidates(primaryGateway, candidateGateways);
+
+    for (const gateway of gateways) {
+      const assetUrl = buildGatewayAssetUrl(gateway, normalizedCid, videoInfoAssetFileName);
+      const payload = await fetchJsonSidecarAsset(assetUrl, options);
+      if (!payload) {
+        continue;
+      }
+
+      const normalizedInfo = normalizeVideoInfo(payload);
+      sidecarVideoInfoCache.set(cacheKey, normalizedInfo);
+      return { ...normalizedInfo };
+    }
+
+    return createDefaultVideoInfo();
+  });
+}
+
+export async function loadSubtitleCatalogWithFallback(cid, primaryGateway = '', candidateGateways = [], options = {}) {
+  const normalizedCid = normalizeString(cid);
+  if (!normalizedCid) {
+    return {
+      status: subtitleCatalogStatus.error,
+      tracks: [],
+    };
+  }
+
+  const cacheKey = createSubtitleManifestCacheKey(normalizedCid);
+  const cachedManifest = sidecarSubtitleManifestCache.get(cacheKey);
+
+  if (cachedManifest) {
+    return {
+      status: cachedManifest.status,
+      tracks: await materializeSubtitleTracks(cachedManifest, normalizedCid, primaryGateway, candidateGateways, options),
+    };
+  }
+
+  return runSidecarRequest(`subtitle-manifest:${normalizedCid}`, async () => {
+    const gateways = buildSidecarGatewayCandidates(primaryGateway, candidateGateways);
+    let sawMissingManifest = false;
+
+    for (const gateway of gateways) {
+      const assetUrl = buildGatewayAssetUrl(gateway, normalizedCid, 'subtitles.json');
+      const response = await fetchJsonSidecarResponse(assetUrl, options);
+
+      if (response.status === 'missing') {
+        sawMissingManifest = true;
+        continue;
+      }
+
+      if (response.status !== 'ok') {
+        continue;
+      }
+
+      const cachedEntry = {
+        status: subtitleCatalogStatus.ready,
+        resolvedGateway: gateway,
+        tracks: cloneManifestTracks(normalizeSubtitleManifest(response.payload)),
+      };
+      sidecarSubtitleManifestCache.set(cacheKey, cachedEntry);
+
+      return {
+        status: cachedEntry.status,
+        tracks: await materializeSubtitleTracks(cachedEntry, normalizedCid, primaryGateway, candidateGateways, options),
+      };
+    }
+
+    if (sawMissingManifest) {
+      return {
+        status: subtitleCatalogStatus.ready,
+        tracks: [],
+      };
+    }
+
+    return {
+      status: subtitleCatalogStatus.error,
+      tracks: [],
+    };
+  });
+}
+
+export function resetSidecarSessionCache(options = {}) {
+  const revokeObjectURL = options.revokeObjectURL ?? globalThis.URL?.revokeObjectURL?.bind(globalThis.URL);
+
+  if (typeof revokeObjectURL === 'function') {
+    sidecarBlobCache.forEach(({ objectUrl }) => {
+      if (normalizeString(objectUrl).startsWith('blob:')) {
+        revokeObjectURL(objectUrl);
+      }
+    });
+  }
+
+  sidecarBlobCache.clear();
+  sidecarVideoInfoCache.clear();
+  sidecarSubtitleManifestCache.clear();
+  inflightSidecarRequests.clear();
+}
+
+async function loadBlobSidecarUrlWithFallback(cid, assetPath, primaryGateway = '', candidateGateways = [], options = {}) {
+  const normalizedCid = normalizeString(cid);
+  const normalizedAssetPath = normalizeString(assetPath);
+
+  if (!normalizedCid || !normalizedAssetPath) {
+    return '';
+  }
+
+  const cacheKey = createSidecarCacheKey(normalizedCid, normalizedAssetPath);
+  const cachedValue = sidecarBlobCache.get(cacheKey);
+  if (cachedValue?.objectUrl) {
+    return cachedValue.objectUrl;
+  }
+
+  return runSidecarRequest(`blob:${cacheKey}`, async () => {
+    const gateways = buildSidecarGatewayCandidates(primaryGateway, candidateGateways);
+
+    for (const gateway of gateways) {
+      const assetUrl = buildGatewayAssetUrl(gateway, normalizedCid, normalizedAssetPath);
+      const objectUrl = await fetchBlobSidecarAsset(assetUrl, options);
+      if (!objectUrl) {
+        continue;
+      }
+
+      sidecarBlobCache.set(cacheKey, {
+        objectUrl,
+        gateway,
+      });
+      return objectUrl;
+    }
+
+    return '';
+  });
+}
+
+function buildResolvedSubtitleTracks(cachedManifest, cid, primaryGateway = '', candidateGateways = [], options = {}) {
+  const gateways = buildSidecarGatewayCandidates(primaryGateway, [
+    cachedManifest?.resolvedGateway || '',
+    ...candidateGateways,
+  ]);
+  const fallbackGateway = cachedManifest?.resolvedGateway || gateways[0] || '';
+
+  return cachedManifest.tracks.map((track, index) => {
+    const objectUrl = readCachedSidecarObjectUrl(cid, track.path);
+    const fallbackUrl = buildGatewayAssetUrl(fallbackGateway, cid, track.path);
+
+    return {
+      lang: track.lang,
+      label: track.label,
+      src: objectUrl || fallbackUrl,
+      path: track.path,
+      fileName: extractFileName(track.path),
+      order: normalizeTrackOrder(track.order, index),
+      source: 'remote',
+    };
+  }).filter((track) => track.src);
+}
+
+async function materializeSubtitleTracks(cachedManifest, cid, primaryGateway = '', candidateGateways = [], options = {}) {
+  const gateways = buildSidecarGatewayCandidates(primaryGateway, [
+    cachedManifest?.resolvedGateway || '',
+    ...candidateGateways,
+  ]);
+  const fallbackGateway = cachedManifest?.resolvedGateway || gateways[0] || '';
+
+  const resolvedTracks = await Promise.all(
+    cachedManifest.tracks.map(async (track, index) => {
+      const objectUrl =
+        readCachedSidecarObjectUrl(cid, track.path) ||
+        (await loadBlobSidecarUrlWithFallback(cid, track.path, primaryGateway, [cachedManifest?.resolvedGateway || '', ...candidateGateways], options));
+      const fallbackUrl = buildGatewayAssetUrl(fallbackGateway, cid, track.path);
+
+      return {
+        lang: track.lang,
+        label: track.label,
+        src: objectUrl || fallbackUrl,
+        path: track.path,
+        fileName: extractFileName(track.path),
+        order: normalizeTrackOrder(track.order, index),
+        source: 'remote',
+      };
+    })
+  );
+
+  return resolvedTracks.filter((track) => track.src);
+}
+
+async function fetchBlobSidecarAsset(assetUrl, options = {}) {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const createObjectURL = options.createObjectURL ?? globalThis.URL?.createObjectURL?.bind(globalThis.URL);
+  const BlobImpl = options.BlobImpl ?? globalThis.Blob;
+
+  if (typeof fetchImpl !== 'function') {
+    return '';
+  }
+
+  try {
+    const response = await fetchImpl(assetUrl, {
+      method: 'GET',
+      mode: 'cors',
+      cache: 'default',
+    });
+
+    if (!response?.ok) {
+      return '';
+    }
+
+    const contentType = response.headers?.get?.('content-type') || '';
+    if (htmlContentTypePattern.test(contentType)) {
+      return '';
+    }
+
+    if (typeof createObjectURL !== 'function') {
+      return assetUrl;
+    }
+
+    const blob =
+      typeof response.blob === 'function'
+        ? await response.blob()
+        : new BlobImpl([await response.text()], { type: contentType || '' });
+
+    return createObjectURL(blob);
+  } catch (_) {
+    return '';
+  }
+}
+
+async function fetchJsonSidecarAsset(assetUrl, options = {}) {
+  const response = await fetchJsonSidecarResponse(assetUrl, options);
+  return response.status === 'ok' ? response.payload : null;
+}
+
+async function fetchJsonSidecarResponse(assetUrl, options = {}) {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+
+  if (typeof fetchImpl !== 'function') {
+    return {
+      status: 'failed',
+      payload: null,
+    };
+  }
+
+  try {
+    const response = await fetchImpl(assetUrl, {
+      method: 'GET',
+      mode: 'cors',
+      cache: 'default',
+      headers: {
+        Accept: 'application/json, text/plain;q=0.9, */*;q=0.1',
+      },
+    });
+
+    if (!response?.ok) {
+      return {
+        status: response?.status === 404 ? 'missing' : 'failed',
+        payload: null,
+      };
+    }
+
+    const contentType = response.headers?.get?.('content-type') || '';
+    if (htmlContentTypePattern.test(contentType)) {
+      return {
+        status: 'failed',
+        payload: null,
+      };
+    }
+
+    return {
+      status: 'ok',
+      payload: await response.json(),
+    };
+  } catch (_) {
+    return {
+      status: 'failed',
+      payload: null,
+    };
+  }
+}
+
+function runSidecarRequest(key, factory) {
+  if (inflightSidecarRequests.has(key)) {
+    return inflightSidecarRequests.get(key);
+  }
+
+  const request = Promise.resolve()
+    .then(factory)
+    .finally(() => {
+      inflightSidecarRequests.delete(key);
+    });
+
+  inflightSidecarRequests.set(key, request);
+  return request;
+}
+
+function cloneManifestTracks(tracks = []) {
+  return tracks.map((track) => ({
+    lang: track.lang,
+    label: track.label,
+    path: track.path,
+    order: track.order,
+  }));
+}
+
+function createSidecarCacheKey(cid, assetPath) {
+  const normalizedCid = normalizeString(cid);
+  const normalizedAssetPath = normalizeString(assetPath);
+  return normalizedCid && normalizedAssetPath ? `${normalizedCid}:${normalizedAssetPath}` : '';
+}
+
+function createVideoInfoCacheKey(cid) {
+  const normalizedCid = normalizeString(cid);
+  return normalizedCid ? `${normalizedCid}:${videoInfoAssetFileName}` : '';
+}
+
+function createSubtitleManifestCacheKey(cid) {
+  const normalizedCid = normalizeString(cid);
+  return normalizedCid ? `${normalizedCid}:subtitles.json` : '';
+}
+
+function normalizeTrackOrder(value, fallback) {
+  return Number.isFinite(Number(value)) ? Number(value) : fallback;
+}
+
+function extractFileName(assetPath) {
+  const normalizedAssetPath = normalizeString(assetPath);
+  if (!normalizedAssetPath) {
+    return '';
+  }
+
+  const segments = normalizedAssetPath.split('/');
+  return segments[segments.length - 1] || normalizedAssetPath;
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/src/utils/sidecarAssets.spec.js
+++ b/src/utils/sidecarAssets.spec.js
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  avatarAssetFileName,
+  buildSidecarGatewayCandidates,
+  loadAvatarUrlWithFallback,
+  loadPosterUrlWithFallback,
+  loadSubtitleCatalogWithFallback,
+  loadVideoInfoWithFallback,
+  posterAssetFileName,
+  readCachedSidecarObjectUrl,
+  readCachedSubtitleCatalog,
+  readCachedVideoInfo,
+  resetSidecarSessionCache,
+} from './sidecarAssets';
+
+function createHeaders(values = {}) {
+  const entries = new Map(Object.entries(values).map(([key, value]) => [key.toLowerCase(), value]));
+
+  return {
+    get(name) {
+      return entries.get(String(name).toLowerCase()) ?? null;
+    },
+  };
+}
+
+class FakeBlob {
+  constructor(parts = [], options = {}) {
+    this.parts = parts;
+    this.type = options.type || '';
+  }
+}
+
+function createJsonResponse(payload, options = {}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    headers: createHeaders({ 'content-type': options.contentType ?? 'application/json' }),
+    json: vi.fn().mockResolvedValue(payload),
+  };
+}
+
+function createBlobResponse(marker, options = {}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    headers: createHeaders({ 'content-type': options.contentType ?? 'image/webp' }),
+    blob: vi.fn().mockResolvedValue(new FakeBlob([marker], { type: options.contentType ?? 'image/webp' })),
+    text: vi.fn().mockResolvedValue(marker),
+  };
+}
+
+beforeEach(() => {
+  resetSidecarSessionCache({ revokeObjectURL: vi.fn() });
+});
+
+describe('buildSidecarGatewayCandidates', () => {
+  it('keeps the primary gateway first, dedupes candidates, and appends built-in fallbacks', () => {
+    expect(
+      buildSidecarGatewayCandidates('https://custom.example/ipfs/', [
+        'https://ipfs.io/ipfs/',
+        'https://custom.example/ipfs/',
+      ])
+    ).toEqual([
+      'https://custom.example/ipfs/',
+      'https://ipfs.io/ipfs/',
+      'https://dweb.link/ipfs/',
+    ]);
+  });
+});
+
+describe('loadVideoInfoWithFallback', () => {
+  it('falls back to another gateway and reuses the cached metadata across gateway switches', async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (url === 'https://broken.example/ipfs/bafy123/info.json') {
+        return createJsonResponse({}, { ok: false, status: 504 });
+      }
+
+      if (url === 'https://dweb.link/ipfs/bafy123/info.json') {
+        return createJsonResponse({
+          title: 'Loaded from fallback',
+          uploader: 'Uploader',
+        });
+      }
+
+      throw new Error(`Unexpected url: ${url}`);
+    });
+
+    await expect(
+      loadVideoInfoWithFallback('bafy123', 'https://broken.example/ipfs/', ['https://dweb.link/ipfs/'], { fetchImpl })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        title: 'Loaded from fallback',
+        uploader: 'Uploader',
+      })
+    );
+
+    expect(readCachedVideoInfo('bafy123')).toEqual(
+      expect.objectContaining({
+        title: 'Loaded from fallback',
+        uploader: 'Uploader',
+      })
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    await expect(
+      loadVideoInfoWithFallback('bafy123', 'https://ipfs.io/ipfs/', ['https://dweb.link/ipfs/'], { fetchImpl })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        title: 'Loaded from fallback',
+        uploader: 'Uploader',
+      })
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('loadPosterUrlWithFallback', () => {
+  it('creates and reuses a CID-scoped object URL for poster sidecars', async () => {
+    const createObjectURL = vi.fn().mockImplementation((blob) => `blob:${blob.parts.join('')}`);
+    const fetchImpl = vi.fn(async (url) => {
+      if (url === `https://broken.example/ipfs/bafy123/${posterAssetFileName}`) {
+        return createBlobResponse('broken', { ok: false, status: 404 });
+      }
+
+      if (url === `https://dweb.link/ipfs/bafy123/${posterAssetFileName}`) {
+        return createBlobResponse('poster');
+      }
+
+      throw new Error(`Unexpected url: ${url}`);
+    });
+
+    await expect(
+      loadPosterUrlWithFallback('bafy123', 'https://broken.example/ipfs/', ['https://dweb.link/ipfs/'], {
+        fetchImpl,
+        createObjectURL,
+        BlobImpl: FakeBlob,
+      })
+    ).resolves.toBe('blob:poster');
+
+    expect(readCachedSidecarObjectUrl('bafy123', posterAssetFileName)).toBe('blob:poster');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    await expect(
+      loadPosterUrlWithFallback('bafy123', 'https://ipfs.io/ipfs/', ['https://dweb.link/ipfs/'], {
+        fetchImpl,
+        createObjectURL,
+        BlobImpl: FakeBlob,
+      })
+    ).resolves.toBe('blob:poster');
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches avatar sidecars independently from posters', async () => {
+    const createObjectURL = vi.fn().mockImplementation((blob) => `blob:${blob.parts.join('')}`);
+    const fetchImpl = vi.fn(async (url) => {
+      if (url === `https://dweb.link/ipfs/bafy123/${avatarAssetFileName}`) {
+        return createBlobResponse('avatar', { contentType: 'image/jpeg' });
+      }
+
+      throw new Error(`Unexpected url: ${url}`);
+    });
+
+    await expect(
+      loadAvatarUrlWithFallback('bafy123', 'https://dweb.link/ipfs/', [], {
+        fetchImpl,
+        createObjectURL,
+        BlobImpl: FakeBlob,
+      })
+    ).resolves.toBe('blob:avatar');
+
+    expect(readCachedSidecarObjectUrl('bafy123', avatarAssetFileName)).toBe('blob:avatar');
+  });
+});
+
+describe('loadSubtitleCatalogWithFallback', () => {
+  it('loads the manifest from a fallback gateway, materializes subtitle files, and reuses them across gateway switches', async () => {
+    const createObjectURL = vi.fn().mockImplementation((blob) => `blob:${blob.parts.join('')}`);
+    const fetchImpl = vi.fn(async (url) => {
+      if (url === 'https://broken.example/ipfs/bafy123/subtitles.json') {
+        return createJsonResponse({}, { ok: false, status: 504 });
+      }
+
+      if (url === 'https://dweb.link/ipfs/bafy123/subtitles.json') {
+        return createJsonResponse({
+          tracks: [{ lang: 'en', path: 'en.vtt' }],
+        });
+      }
+
+      if (url === 'https://broken.example/ipfs/bafy123/en.vtt') {
+        return createBlobResponse('subtitle-broken', { ok: false, status: 404, contentType: 'text/vtt' });
+      }
+
+      if (url === 'https://dweb.link/ipfs/bafy123/en.vtt') {
+        return createBlobResponse('subtitle-en', { contentType: 'text/vtt' });
+      }
+
+      throw new Error(`Unexpected url: ${url}`);
+    });
+
+    await expect(
+      loadSubtitleCatalogWithFallback('bafy123', 'https://broken.example/ipfs/', ['https://dweb.link/ipfs/'], {
+        fetchImpl,
+        createObjectURL,
+        BlobImpl: FakeBlob,
+      })
+    ).resolves.toEqual({
+      status: 'ready',
+      tracks: [
+        {
+          lang: 'en',
+          label: 'English',
+          src: 'blob:subtitle-en',
+          path: 'en.vtt',
+          fileName: 'en.vtt',
+          order: 0,
+          source: 'remote',
+        },
+      ],
+    });
+
+    const cachedCatalog = readCachedSubtitleCatalog('bafy123', 'https://ipfs.io/ipfs/', ['https://dweb.link/ipfs/']);
+    expect(cachedCatalog).toEqual({
+      status: 'ready',
+      tracks: [
+        {
+          lang: 'en',
+          label: 'English',
+          src: 'blob:subtitle-en',
+          path: 'en.vtt',
+          fileName: 'en.vtt',
+          order: 0,
+          source: 'remote',
+        },
+      ],
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+
+    await expect(
+      loadSubtitleCatalogWithFallback('bafy123', 'https://ipfs.io/ipfs/', ['https://dweb.link/ipfs/'], {
+        fetchImpl,
+        createObjectURL,
+        BlobImpl: FakeBlob,
+      })
+    ).resolves.toEqual(cachedCatalog);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns ready with no tracks when every gateway reports the manifest as missing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(createJsonResponse({}, { ok: false, status: 404 }));
+
+    await expect(
+      loadSubtitleCatalogWithFallback('bafy123', 'https://ipfs.io/ipfs/', ['https://dweb.link/ipfs/'], { fetchImpl })
+    ).resolves.toEqual({
+      status: 'ready',
+      tracks: [],
+    });
+  });
+});


### PR DESCRIPTION
## Why
切換同一個 CID 的 gateway 時，sidecar 目前會跟著新 gateway URL 重新載入，造成不必要的流量、封面與資訊閃動，以及 metadata / subtitles 體驗退化。這個 PR把 sidecar plane 從 media plane 拆開，讓 sidecar 能以 CID 為主體快取與 fallback，而不改動影片播放來源。

## What
- 新增 session 級 sidecar service，對 `cover.webp`、`avatar.jpg`、`info.json`、`subtitles.json` 與 remote subtitle 檔做 CID/path 級快取。
- sidecar 請求改成 current gateway 優先，失敗時依 Header probe 候選與 built-in public gateways fallback。
- `App.vue` 在同 CID 切 gateway 時優先重用 sidecar 快取，不再因 gateway URL 變動就重抓 metadata 與字幕。
- `VideoInfo` / `WatchPage` 改成顯式使用 sidecar avatar URL，避免元件自行重拼 gateway sidecar 路徑。
- 補上 sidecar service 單元測試與 layout / header contract test。

## Validation
- `npm test`
- `npm run build`

## Risks
- sidecar 快取目前是 browser session 級，不跨 session 持久化。
- 這個 PR不處理 `index.m3u8`、variant playlists、segments 的 handoff；media plane 留在 `#3`。

Closes #4