### PR TITLE
feature(player): gateway 切換採用 media hard handoff v1

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -178,12 +178,23 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
 import {
+  fetchGatewayVariantPlaylists,
   gatewayProbePlaybackRateThreshold,
   gatewayProbeSegmentSampleCount,
   isLoopbackGatewayUrl,
   probeGatewayAvailability,
   shouldAutoFallbackGateway,
 } from '../utils/gateway';
+import {
+  applyQualityLevelHeightLock,
+  buildMediaHandoffQualitySnapshot,
+  isSuccessfulMediaHandoffSegmentResponse,
+  mediaHandoffQualityModeAuto,
+  mediaHandoffQualityModeManual,
+  resumeMediaHandoffPlayback,
+  rewriteMediaHandoffRequestUri,
+  selectMediaHandoffLockedHeight,
+} from '../utils/mediaHandoff';
 import { formatTime } from '../utils/time';
 import { applyPlaybackHotkey, getPlayerPlaybackSnapshot } from '../utils/playback';
 import {
@@ -682,6 +693,10 @@ let startupInitialRenditionCount = null;
 let pendingSourceStartTime = 0;
 let pendingSourceShouldAutoplay = false;
 let lastGatewayFallbackKey = '';
+let mediaRequestGateway = '';
+let mediaRequestCid = '';
+let activeVhsXhr = null;
+let activeGatewayHandoff = null;
 const showStartupGate = ref(false);
 const startupGateTitle = ref('');
 const startupGateDetail = ref('');
@@ -1490,6 +1505,77 @@ function syncQualitySelectorButtonLabel() {
   labelEl.textContent = formatQualitySelectorLabel(player.qualityLevels());
 }
 
+function syncMediaRequestRouting(cid = props.cid, gateway = props.gateway) {
+  mediaRequestCid = typeof cid === 'string' ? cid.trim() : '';
+  mediaRequestGateway = typeof gateway === 'string' ? gateway.trim() : '';
+}
+
+function clearGatewayHandoffState() {
+  activeGatewayHandoff = null;
+}
+
+function applyHandoffQualityLock(targetHeight) {
+  if (!player || typeof player.qualityLevels !== 'function' || !Number.isFinite(targetHeight)) {
+    return false;
+  }
+
+  const didLock = applyQualityLevelHeightLock(player.qualityLevels(), targetHeight);
+  if (didLock) {
+    emitQualityLevels();
+    syncQualitySelectorButtonLabel();
+  }
+  return didLock;
+}
+
+function handleVhsRequest(options) {
+  const nextOptions = options ? { ...options } : {};
+  const rewrittenUri = rewriteMediaHandoffRequestUri(nextOptions.uri, {
+    cid: mediaRequestCid,
+    gateway: mediaRequestGateway,
+  });
+
+  if (rewrittenUri) {
+    nextOptions.uri = rewrittenUri;
+  }
+
+  return nextOptions;
+}
+
+function handleVhsResponse(request, error, response) {
+  if (
+    !activeGatewayHandoff ||
+    !isSuccessfulMediaHandoffSegmentResponse(request, error, response, {
+      cid: activeGatewayHandoff.cid,
+      gateway: activeGatewayHandoff.targetGateway,
+    })
+  ) {
+    return;
+  }
+
+  emit('status-update', '新 gateway 已接手後續片段');
+  clearGatewayHandoffState();
+}
+
+function bindVhsXhrHooks() {
+  if (!player) return;
+
+  const xhr = player.tech()?.vhs?.xhr;
+  if (!xhr || activeVhsXhr === xhr) {
+    return;
+  }
+
+  if (activeVhsXhr?.offRequest) {
+    activeVhsXhr.offRequest(handleVhsRequest);
+  }
+  if (activeVhsXhr?.offResponse) {
+    activeVhsXhr.offResponse(handleVhsResponse);
+  }
+
+  xhr.onRequest?.(handleVhsRequest);
+  xhr.onResponse?.(handleVhsResponse);
+  activeVhsXhr = xhr;
+}
+
 function createStartupInitialPlaylistSelector(maxInitialRenditions) {
   return function selectStartupInitialPlaylist() {
     return pickStartupInitialPlaylist(this?.playlists?.main?.playlists, maxInitialRenditions);
@@ -1968,6 +2054,8 @@ async function setupSourceAndTracks(m3u8Url, subtitles, options = {}) {
     switchMode === SOURCE_SWITCH_MODE_GATEWAY_HANDOFF ? cutoverSnapshot?.shouldAutoplay ?? false : props.shouldAutoplay;
 
   const seq = beginSourceSwitch();
+  clearGatewayHandoffState();
+  syncMediaRequestRouting(props.cid, props.gateway);
 
   if (switchMode === SOURCE_SWITCH_MODE_GATEWAY_HANDOFF) {
     updateStartupGate(
@@ -2031,6 +2119,110 @@ async function setupSourceAndTracks(m3u8Url, subtitles, options = {}) {
     emit('status-update', '正在累積可播緩衝...');
     updateStartupGateFromBuffer();
   });
+}
+
+async function performGatewayMediaHandoff(m3u8Url, options = {}) {
+  if (!player) return;
+
+  const {
+    requestedStartTime = props.startTime,
+  } = options;
+
+  if (!player.currentSrc?.()) {
+    await setupSourceAndTracks(m3u8Url, props.subtitles, {
+      switchMode: SOURCE_SWITCH_MODE_DEFAULT,
+      requestedStartTime,
+    });
+    return;
+  }
+
+  const setupRequestId = ++sourceSetupRequestSeq;
+  const handoffSnapshot = getCurrentSourceSwitchSnapshot();
+  const probeStartTime = handoffSnapshot?.time ?? 0;
+  const qualitySnapshot =
+    typeof player.qualityLevels === 'function'
+      ? buildMediaHandoffQualitySnapshot(player.qualityLevels())
+      : null;
+  const variantPlaylistsPromise = fetchGatewayVariantPlaylists(props.gateway, props.cid, {
+    cacheMode: 'default',
+  });
+  const warmupPromise = probeGatewayAvailability(props.gateway, props.cid, {
+    cacheMode: 'default',
+    segmentSampleCount: gatewayProbeSegmentSampleCount,
+    playbackRateThreshold: gatewayProbePlaybackRateThreshold,
+    startTimeSeconds: probeStartTime,
+    onProgress(progressState) {
+      if (!player || setupRequestId !== sourceSetupRequestSeq || progressState.state !== 'probing') return;
+
+      const progressLabel =
+        progressState.sampleSegmentCount > 0
+          ? `已完成 ${progressState.completedSampleCount}/${progressState.sampleSegmentCount} 個片段`
+          : '正在測速';
+      const speedLabel = Number.isFinite(progressState.playbackRate)
+        ? `，目前約 ${formatPlaybackRateLabel(progressState.playbackRate)}`
+        : '';
+      emit('status-update', `新 gateway 預載中：${progressLabel}${speedLabel}`);
+    },
+  });
+
+  emit('status-update', '正在為新 gateway 預載目前播放位置...');
+
+  const variantPlaylists = await variantPlaylistsPromise;
+  if (!player || setupRequestId !== sourceSetupRequestSeq) return;
+
+  const availableHeights = variantPlaylists
+    .map((playlist) => (Number.isFinite(playlist?.height) ? playlist.height : null))
+    .filter((height) => Number.isFinite(height) && height > 0);
+  const lockedHeight = selectMediaHandoffLockedHeight(qualitySnapshot, availableHeights);
+  applyHandoffQualityLock(lockedHeight);
+
+  activeGatewayHandoff = {
+    cid: props.cid,
+    targetGateway: props.gateway,
+  };
+  syncMediaRequestRouting(props.cid, props.gateway);
+  const recoveryResult = resumeMediaHandoffPlayback(player, {
+    shouldAutoplay: handoffSnapshot?.shouldAutoplay ?? false,
+  });
+
+  if (qualitySnapshot?.mode === mediaHandoffQualityModeManual && Number.isFinite(lockedHeight)) {
+    emit('status-update', `已切換到新 gateway，沿用 ${lockedHeight}p 接手後續片段`);
+  } else if (
+    qualitySnapshot?.mode === mediaHandoffQualityModeAuto &&
+    Number.isFinite(qualitySnapshot?.activeHeight) &&
+    Number.isFinite(lockedHeight) &&
+    lockedHeight !== qualitySnapshot.activeHeight
+  ) {
+    emit('status-update', `已切換到新 gateway，handoff 期間暫時改用 ${lockedHeight}p`);
+  } else {
+    emit('status-update', handoffSnapshot?.shouldAutoplay ? '已切換到新 gateway，等待後續片段接手' : '新 gateway 已就緒，等待繼續播放');
+  }
+
+  if (recoveryResult.didClearError || recoveryResult.reincludedPlaylistCount > 0) {
+    emit('status-update', '已清除前一次失敗的下載狀態，重新向目前 gateway 請求片段');
+  }
+
+  const warmupResult = await warmupPromise;
+  if (!player || setupRequestId !== sourceSetupRequestSeq) return;
+
+  if (
+    shouldAutoFallbackGateway(props.gateway, warmupResult) &&
+    requestGatewayFallback(warmupResult, {
+      dedupeKey: `warmup:${setupRequestId}`,
+      startTime: probeStartTime,
+      shouldAutoplay: handoffSnapshot?.shouldAutoplay ?? props.shouldAutoplay,
+    })
+  ) {
+    return;
+  }
+
+  if (
+    activeGatewayHandoff &&
+    activeGatewayHandoff.targetGateway === props.gateway &&
+    (warmupResult?.state === 'failed' || warmupResult?.state === 'degraded')
+  ) {
+    emit('status-update', '新 gateway 尚未通過預載檢查，將先沿用既有緩衝並等待下一次請求');
+  }
 }
 
 function clearTracks() {
@@ -2263,6 +2455,7 @@ function initPlayer() {
       bindPlaybackSnapshotListeners();
       bindStartupGateListeners();
       bindQualityLevelListeners();
+      player.on('xhr-hooks-ready', bindVhsXhrHooks);
       observeSubtitleCueDisplay();
       player.on('texttrackchange', scheduleSubtitleCueRoleClassSync);
       player.on('playerresize', () => {
@@ -2284,6 +2477,7 @@ function initPlayer() {
       syncPoster(props.posterUrl);
       emit('status-update', '播放器已就緒');
       if (props.m3u8Url) {
+        syncMediaRequestRouting(props.cid, props.gateway);
         void setupSourceAndTracks(props.m3u8Url, props.subtitles, {
           switchMode: SOURCE_SWITCH_MODE_DEFAULT,
           requestedStartTime: props.startTime,
@@ -2304,6 +2498,8 @@ watch(
     if (!player) return;
 
     if (!newUrl) {
+      clearGatewayHandoffState();
+      syncMediaRequestRouting('', '');
       pendingSourceStartTime = 0;
       pendingSourceShouldAutoplay = false;
       beginSourceSwitch();
@@ -2312,12 +2508,21 @@ watch(
     }
 
     if (newUrl !== oldUrl) {
+      const switchMode = resolveSourceSwitchMode(newUrl, {
+        oldUrl,
+        oldCid,
+        oldGateway,
+      });
+
+      if (switchMode === SOURCE_SWITCH_MODE_GATEWAY_HANDOFF) {
+        void performGatewayMediaHandoff(newUrl, {
+          requestedStartTime: newStartTime,
+        });
+        return;
+      }
+
       void setupSourceAndTracks(newUrl, props.subtitles, {
-        switchMode: resolveSourceSwitchMode(newUrl, {
-          oldUrl,
-          oldCid,
-          oldGateway,
-        }),
+        switchMode,
         requestedStartTime: newStartTime,
       });
       return;
@@ -2412,6 +2617,14 @@ onBeforeUnmount(() => {
     qualityLevelList.off('removequalitylevel', handleQualityLevelsChanged);
     qualityLevelList = null;
   }
+  if (activeVhsXhr?.offRequest) {
+    activeVhsXhr.offRequest(handleVhsRequest);
+  }
+  if (activeVhsXhr?.offResponse) {
+    activeVhsXhr.offResponse(handleVhsResponse);
+  }
+  activeVhsXhr = null;
+  clearGatewayHandoffState();
   if (player) {
     player.dualSubtitleSwapAction_ = null;
     player.dualSubtitleSwapState_ = null;
@@ -2419,6 +2632,7 @@ onBeforeUnmount(() => {
     player.subtitleVisibilityToggleState_ = null;
     player.primarySubtitleMenuToggle_ = null;
     player.primarySubtitleControlState_ = null;
+    player.off?.('xhr-hooks-ready', bindVhsXhrHooks);
     emitPlaybackSnapshot('before-unmount', { force: true });
     player.dispose();
   }

--- a/src/utils/gateway.js
+++ b/src/utils/gateway.js
@@ -211,6 +211,44 @@ export function buildGatewayIndexUrl(gatewayUrl, cid) {
   return buildGatewayAssetUrl(gatewayUrl, cid, 'index.m3u8');
 }
 
+export async function fetchGatewayVariantPlaylists(gatewayUrl, cid, options = {}) {
+  const {
+    fetchImpl = globalThis.fetch,
+    timeoutMs = gatewayProbeTimeoutMs,
+    cacheMode = 'no-store',
+  } = options;
+  const playlistUrl = buildGatewayIndexUrl(gatewayUrl, cid);
+
+  if (!playlistUrl || typeof fetchImpl !== 'function') {
+    return [];
+  }
+
+  const controller = new AbortController();
+  const timeoutId =
+    timeoutMs > 0
+      ? setTimeout(() => {
+          controller.abort();
+        }, timeoutMs)
+      : null;
+
+  try {
+    const playlistResponse = await fetchGatewayTextResource(playlistUrl, fetchImpl, controller.signal, cacheMode);
+    if (!playlistResponse?.ok) {
+      return [];
+    }
+
+    const playlistText = await readTextResponse(playlistResponse);
+    const parsedPlaylist = parseHlsPlaylist(playlistText, playlistUrl);
+    return orderVariantPlaylistsByBandwidth(parsedPlaylist.variantPlaylists);
+  } catch (_) {
+    return [];
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 export async function probeGatewayAvailability(gatewayUrl, cid, options = {}) {
   const {
     fetchImpl = globalThis.fetch,
@@ -595,6 +633,7 @@ function parseHlsPlaylist(playlistText, baseUrl) {
   const lines = String(playlistText || '').split(/\r?\n/);
   let expectsVariantUri = false;
   let pendingVariantBandwidth = null;
+  let pendingVariantResolution = null;
   let pendingSegmentDuration = null;
 
   lines.forEach((rawLine) => {
@@ -615,6 +654,7 @@ function parseHlsPlaylist(playlistText, baseUrl) {
     if (line.startsWith('#EXT-X-STREAM-INF')) {
       expectsVariantUri = true;
       pendingVariantBandwidth = parseBandwidth(line);
+      pendingVariantResolution = parseResolution(line);
       return;
     }
 
@@ -637,9 +677,12 @@ function parseHlsPlaylist(playlistText, baseUrl) {
       variantPlaylists.push({
         url: resolvedUrl,
         bandwidth: pendingVariantBandwidth,
+        width: Number.isFinite(pendingVariantResolution?.width) ? pendingVariantResolution.width : null,
+        height: Number.isFinite(pendingVariantResolution?.height) ? pendingVariantResolution.height : null,
       });
       expectsVariantUri = false;
       pendingVariantBandwidth = null;
+      pendingVariantResolution = null;
       return;
     }
 
@@ -692,8 +735,20 @@ function parsePlaylistTagUri(line, tagPrefix) {
 }
 
 function parseBandwidth(line) {
-  const match = line.match(/(?:^|,)BANDWIDTH=(\d+)/i);
+  const match = line.match(/(?:^|:|,)BANDWIDTH=(\d+)/i);
   return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function parseResolution(line) {
+  const match = line.match(/(?:^|:|,)RESOLUTION=(\d+)x(\d+)/i);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    width: Number.parseInt(match[1], 10),
+    height: Number.parseInt(match[2], 10),
+  };
 }
 
 function parseExtinfDuration(line) {

--- a/src/utils/gateway.spec.js
+++ b/src/utils/gateway.spec.js
@@ -3,6 +3,7 @@ import {
   buildGatewayAssetUrl,
   buildGatewayIndexUrl,
   customGatewayStorageKey,
+  fetchGatewayVariantPlaylists,
   gatewayRateLimitBackoffMs,
   gatewayProbeSegmentSampleCount,
   gatewayStorageKey,
@@ -637,5 +638,62 @@ describe('probeGatewayAvailability', () => {
       sampleSegmentCount: 0,
       completedSampleCount: 0,
     });
+  });
+});
+
+describe('fetchGatewayVariantPlaylists', () => {
+  it('returns sorted variant playlists with parsed resolution metadata', async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (url === 'https://example.com/ipfs/bafy123/index.m3u8') {
+        return createResponse({
+          text: [
+            '#EXTM3U',
+            '#EXT-X-STREAM-INF:BANDWIDTH=3000000,RESOLUTION=1280x720',
+            '720p/streaminglist-720p.m3u8',
+            '#EXT-X-STREAM-INF:BANDWIDTH=1500000,RESOLUTION=854x480',
+            '480p/streaminglist-480p.m3u8',
+          ].join('\n'),
+        });
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await expect(
+      fetchGatewayVariantPlaylists('https://example.com/ipfs/', 'bafy123', {
+        fetchImpl,
+      })
+    ).resolves.toEqual([
+      {
+        url: 'https://example.com/ipfs/bafy123/480p/streaminglist-480p.m3u8',
+        bandwidth: 1500000,
+        width: 854,
+        height: 480,
+      },
+      {
+        url: 'https://example.com/ipfs/bafy123/720p/streaminglist-720p.m3u8',
+        bandwidth: 3000000,
+        width: 1280,
+        height: 720,
+      },
+    ]);
+  });
+
+  it('returns an empty list for media playlists without variant entries', async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (url === 'https://example.com/ipfs/bafy123/index.m3u8') {
+        return createResponse({
+          text: '#EXTM3U\n#EXTINF:5.0,\nsegment_000.ts\n',
+        });
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await expect(
+      fetchGatewayVariantPlaylists('https://example.com/ipfs/', 'bafy123', {
+        fetchImpl,
+      })
+    ).resolves.toEqual([]);
   });
 });

--- a/src/utils/mediaHandoff.js
+++ b/src/utils/mediaHandoff.js
@@ -1,0 +1,341 @@
+import { buildGatewayAssetUrl } from './gateway';
+
+export const mediaHandoffQualityModeAuto = 'auto';
+export const mediaHandoffQualityModeManual = 'manual';
+export const mediaHandoffQualityModeUnknown = 'unknown';
+export const mediaHandoffRequestKindManifest = 'manifest';
+export const mediaHandoffRequestKindSegment = 'segment';
+export const mediaHandoffRequestKindUnknown = 'unknown';
+
+export function buildMediaHandoffQualitySnapshot(qualityLevels) {
+  const normalizedLevels = collectNormalizedQualityLevels(qualityLevels);
+
+  if (normalizedLevels.length === 0) {
+    return {
+      mode: mediaHandoffQualityModeUnknown,
+      activeHeight: null,
+      lockedHeight: null,
+      allHeights: [],
+      enabledHeights: [],
+    };
+  }
+
+  const allHeights = dedupeHeights(normalizedLevels.map((level) => level.height));
+  const enabledHeights = dedupeHeights(normalizedLevels.filter((level) => level.enabled).map((level) => level.height));
+  const activeHeight = resolveActiveQualityHeight(qualityLevels, normalizedLevels);
+  const mode =
+    enabledHeights.length > 0 && enabledHeights.length < allHeights.length
+      ? mediaHandoffQualityModeManual
+      : mediaHandoffQualityModeAuto;
+  const lockedHeight =
+    mode === mediaHandoffQualityModeManual
+      ? resolveManualLockedHeight(enabledHeights, activeHeight)
+      : Number.isFinite(activeHeight)
+        ? activeHeight
+        : null;
+
+  return {
+    mode,
+    activeHeight: Number.isFinite(activeHeight) ? activeHeight : null,
+    lockedHeight: Number.isFinite(lockedHeight) ? lockedHeight : null,
+    allHeights,
+    enabledHeights,
+  };
+}
+
+export function selectMediaHandoffLockedHeight(snapshot, availableVariantHeights = []) {
+  const preferredHeight =
+    snapshot?.mode === mediaHandoffQualityModeManual ? snapshot?.lockedHeight : snapshot?.activeHeight;
+
+  if (!Number.isFinite(preferredHeight)) {
+    return null;
+  }
+
+  const normalizedHeights = dedupeHeights(availableVariantHeights);
+  if (normalizedHeights.length === 0) {
+    return preferredHeight;
+  }
+
+  if (normalizedHeights.includes(preferredHeight)) {
+    return preferredHeight;
+  }
+
+  const lowerHeights = normalizedHeights.filter((height) => height < preferredHeight);
+  if (lowerHeights.length > 0) {
+    return lowerHeights[lowerHeights.length - 1];
+  }
+
+  const higherHeights = normalizedHeights.filter((height) => height > preferredHeight);
+  return higherHeights[0] || preferredHeight;
+}
+
+export function applyQualityLevelHeightLock(qualityLevels, targetHeight) {
+  if (!qualityLevels || !Number.isFinite(qualityLevels.length)) {
+    return false;
+  }
+
+  const unlockToAuto = targetHeight === mediaHandoffQualityModeAuto;
+  let matched = false;
+
+  for (let index = 0; index < qualityLevels.length; index += 1) {
+    const level = qualityLevels[index];
+    if (!level) {
+      continue;
+    }
+
+    const levelHeight = getQualityLevelHeight(level);
+    const shouldEnable = unlockToAuto ? true : levelHeight === targetHeight;
+
+    if (!unlockToAuto && levelHeight === targetHeight) {
+      matched = true;
+    }
+
+    level.enabled = shouldEnable;
+  }
+
+  return unlockToAuto ? true : matched;
+}
+
+export function rewriteMediaHandoffRequestUri(uri, options = {}) {
+  const { cid = '', gateway = '' } = options;
+  const resolvedAsset = extractMediaAssetDescriptor(uri, cid);
+
+  if (!resolvedAsset || !gateway) {
+    return '';
+  }
+
+  const baseUri = buildGatewayAssetUrl(gateway, cid, resolvedAsset.assetPath);
+  if (!baseUri) {
+    return '';
+  }
+
+  return `${baseUri}${resolvedAsset.search}${resolvedAsset.hash}`;
+}
+
+export function classifyMediaHandoffRequestKind(uri) {
+  try {
+    const { pathname } = new URL(uri);
+    return /\.m3u8?$/i.test(pathname) ? mediaHandoffRequestKindManifest : mediaHandoffRequestKindSegment;
+  } catch (_) {
+    return mediaHandoffRequestKindUnknown;
+  }
+}
+
+export function isSuccessfulMediaHandoffSegmentResponse(request, error, response, options = {}) {
+  if (error) {
+    return false;
+  }
+
+  const requestUri =
+    typeof request?.uri === 'string' && request.uri
+      ? request.uri
+      : typeof request?.url === 'string' && request.url
+        ? request.url
+        : '';
+
+  if (!requestUri || classifyMediaHandoffRequestKind(requestUri) !== mediaHandoffRequestKindSegment) {
+    return false;
+  }
+
+  const rewrittenUri = rewriteMediaHandoffRequestUri(requestUri, options);
+  if (!rewrittenUri || normalizeComparableUrl(rewrittenUri) !== normalizeComparableUrl(requestUri)) {
+    return false;
+  }
+
+  const status = Number(response?.statusCode ?? response?.status ?? request?.statusCode ?? request?.status);
+  return Number.isFinite(status) && status >= 200 && status < 400;
+}
+
+export function clearRecoverableMediaPlaylistExclusions(playlists = []) {
+  let clearedCount = 0;
+
+  playlists.forEach((playlist) => {
+    if (!playlist || typeof playlist !== 'object') {
+      return;
+    }
+
+    const isNonUsableExclusion =
+      playlist.excludeUntil === Infinity && playlist.lastExcludeReason_ === 'non-usable';
+
+    if (isNonUsableExclusion) {
+      return;
+    }
+
+    if (typeof playlist.excludeUntil !== 'undefined') {
+      delete playlist.excludeUntil;
+      clearedCount += 1;
+    }
+
+    if (playlist.lastExcludeReason_) {
+      delete playlist.lastExcludeReason_;
+    }
+  });
+
+  return clearedCount;
+}
+
+export function resumeMediaHandoffPlayback(player, options = {}) {
+  const { shouldAutoplay = false } = options;
+  const vhs = player?.tech?.()?.vhs;
+  const playlistController = vhs?.playlistController_ || vhs?.playlistController;
+
+  if (!playlistController) {
+    return {
+      didClearError: false,
+      reincludedPlaylistCount: 0,
+      didResumeLoading: false,
+    };
+  }
+
+  const mainPlaylists =
+    playlistController?.mainPlaylistLoader_?.main?.playlists || vhs?.playlists?.main?.playlists || [];
+  const reincludedPlaylistCount = clearRecoverableMediaPlaylistExclusions(mainPlaylists);
+  const didClearError = clearPlayerError(player);
+
+  if (playlistController.mainPlaylistLoader_) {
+    playlistController.mainPlaylistLoader_.error = null;
+    playlistController.mainPlaylistLoader_.load?.();
+  }
+
+  playlistController.error = null;
+  playlistController.mainSegmentLoader_?.error?.(null);
+  playlistController.audioSegmentLoader_?.error?.(null);
+  playlistController.subtitleSegmentLoader_?.error?.(null);
+
+  if (shouldAutoplay && typeof playlistController.play === 'function') {
+    playlistController.play();
+    return {
+      didClearError,
+      reincludedPlaylistCount,
+      didResumeLoading: true,
+    };
+  }
+
+  playlistController.load?.();
+  return {
+    didClearError,
+    reincludedPlaylistCount,
+    didResumeLoading: true,
+  };
+}
+
+function collectNormalizedQualityLevels(qualityLevels) {
+  const levels = [];
+  const total = Number.isFinite(qualityLevels?.length) ? qualityLevels.length : 0;
+
+  for (let index = 0; index < total; index += 1) {
+    const level = qualityLevels[index];
+    const height = getQualityLevelHeight(level);
+
+    if (!Number.isFinite(height)) {
+      continue;
+    }
+
+    levels.push({
+      index,
+      height,
+      enabled: level?.enabled !== false,
+    });
+  }
+
+  return levels;
+}
+
+function resolveActiveQualityHeight(qualityLevels, normalizedLevels) {
+  const selectedIndex = Number.isFinite(qualityLevels?.selectedIndex) ? qualityLevels.selectedIndex : -1;
+  if (selectedIndex >= 0 && selectedIndex < (qualityLevels?.length || 0)) {
+    const selectedHeight = getQualityLevelHeight(qualityLevels[selectedIndex]);
+    if (Number.isFinite(selectedHeight)) {
+      return selectedHeight;
+    }
+  }
+
+  const enabledLevels = normalizedLevels.filter((level) => level.enabled);
+  if (enabledLevels.length > 0) {
+    return enabledLevels[enabledLevels.length - 1].height;
+  }
+
+  return normalizedLevels[normalizedLevels.length - 1]?.height ?? null;
+}
+
+function resolveManualLockedHeight(enabledHeights, activeHeight) {
+  if (Number.isFinite(activeHeight) && enabledHeights.includes(activeHeight)) {
+    return activeHeight;
+  }
+
+  return enabledHeights[enabledHeights.length - 1] ?? null;
+}
+
+function dedupeHeights(values) {
+  return [...new Set(values.filter((value) => Number.isFinite(value) && value > 0))].sort((left, right) => left - right);
+}
+
+function getQualityLevelHeight(level) {
+  if (!level) {
+    return Number.NaN;
+  }
+
+  const width = Number.isFinite(level.width) ? level.width : Number.NaN;
+  const height = Number.isFinite(level.height) ? level.height : Number.NaN;
+
+  if (!Number.isFinite(width) && !Number.isFinite(height)) {
+    return Number.NaN;
+  }
+
+  if (!Number.isFinite(width)) {
+    return height;
+  }
+
+  if (!Number.isFinite(height)) {
+    return width;
+  }
+
+  return Math.min(width, height);
+}
+
+function extractMediaAssetDescriptor(uri, cid) {
+  const normalizedCid = typeof cid === 'string' ? cid.trim() : '';
+  if (!normalizedCid) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(uri);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const ipfsIndex = segments.findIndex((segment) => segment === 'ipfs');
+
+    if (ipfsIndex < 0 || segments[ipfsIndex + 1] !== normalizedCid) {
+      return null;
+    }
+
+    return {
+      assetPath: segments.slice(ipfsIndex + 2).join('/'),
+      search: parsed.search || '',
+      hash: parsed.hash || '',
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+function normalizeComparableUrl(uri) {
+  try {
+    return new URL(uri).toString();
+  } catch (_) {
+    return '';
+  }
+}
+
+function clearPlayerError(player) {
+  if (!player || typeof player.error !== 'function') {
+    return false;
+  }
+
+  const currentError = player.error();
+  if (!currentError) {
+    return false;
+  }
+
+  player.error(null);
+  return true;
+}

--- a/src/utils/mediaHandoff.spec.js
+++ b/src/utils/mediaHandoff.spec.js
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyQualityLevelHeightLock,
+  buildMediaHandoffQualitySnapshot,
+  clearRecoverableMediaPlaylistExclusions,
+  classifyMediaHandoffRequestKind,
+  isSuccessfulMediaHandoffSegmentResponse,
+  mediaHandoffQualityModeAuto,
+  mediaHandoffQualityModeManual,
+  mediaHandoffRequestKindManifest,
+  mediaHandoffRequestKindSegment,
+  resumeMediaHandoffPlayback,
+  rewriteMediaHandoffRequestUri,
+  selectMediaHandoffLockedHeight,
+} from './mediaHandoff';
+
+describe('buildMediaHandoffQualitySnapshot', () => {
+  it('treats fully enabled levels as auto mode and uses the active rendition height', () => {
+    const qualityLevels = {
+      length: 3,
+      selectedIndex: 2,
+      0: { width: 854, height: 480, enabled: true },
+      1: { width: 1280, height: 720, enabled: true },
+      2: { width: 1920, height: 1080, enabled: true },
+    };
+
+    expect(buildMediaHandoffQualitySnapshot(qualityLevels)).toEqual({
+      mode: mediaHandoffQualityModeAuto,
+      activeHeight: 1080,
+      lockedHeight: 1080,
+      allHeights: [480, 720, 1080],
+      enabledHeights: [480, 720, 1080],
+    });
+  });
+
+  it('treats partially enabled levels as manual mode and preserves the pinned quality', () => {
+    const qualityLevels = {
+      length: 3,
+      selectedIndex: 1,
+      0: { width: 854, height: 480, enabled: false },
+      1: { width: 1280, height: 720, enabled: true },
+      2: { width: 1920, height: 1080, enabled: false },
+    };
+
+    expect(buildMediaHandoffQualitySnapshot(qualityLevels)).toEqual({
+      mode: mediaHandoffQualityModeManual,
+      activeHeight: 720,
+      lockedHeight: 720,
+      allHeights: [480, 720, 1080],
+      enabledHeights: [720],
+    });
+  });
+});
+
+describe('selectMediaHandoffLockedHeight', () => {
+  it('prefers the exact same resolution when available', () => {
+    expect(
+      selectMediaHandoffLockedHeight(
+        {
+          mode: mediaHandoffQualityModeManual,
+          activeHeight: 720,
+          lockedHeight: 720,
+        },
+        [480, 720, 1080]
+      )
+    ).toBe(720);
+  });
+
+  it('falls back to the nearest lower resolution before trying a higher one', () => {
+    expect(
+      selectMediaHandoffLockedHeight(
+        {
+          mode: mediaHandoffQualityModeAuto,
+          activeHeight: 720,
+          lockedHeight: 720,
+        },
+        [360, 480, 1080]
+      )
+    ).toBe(480);
+  });
+
+  it('uses the nearest higher resolution only when no lower one exists', () => {
+    expect(
+      selectMediaHandoffLockedHeight(
+        {
+          mode: mediaHandoffQualityModeManual,
+          activeHeight: 480,
+          lockedHeight: 480,
+        },
+        [720, 1080]
+      )
+    ).toBe(720);
+  });
+});
+
+describe('applyQualityLevelHeightLock', () => {
+  it('pins the matching quality level height', () => {
+    const qualityLevels = {
+      length: 3,
+      0: { width: 854, height: 480, enabled: true },
+      1: { width: 1280, height: 720, enabled: true },
+      2: { width: 1920, height: 1080, enabled: true },
+    };
+
+    expect(applyQualityLevelHeightLock(qualityLevels, 720)).toBe(true);
+    expect(qualityLevels[0].enabled).toBe(false);
+    expect(qualityLevels[1].enabled).toBe(true);
+    expect(qualityLevels[2].enabled).toBe(false);
+  });
+
+  it('releases the lock back to auto by enabling every level', () => {
+    const qualityLevels = {
+      length: 2,
+      0: { width: 854, height: 480, enabled: false },
+      1: { width: 1280, height: 720, enabled: true },
+    };
+
+    expect(applyQualityLevelHeightLock(qualityLevels, mediaHandoffQualityModeAuto)).toBe(true);
+    expect(qualityLevels[0].enabled).toBe(true);
+    expect(qualityLevels[1].enabled).toBe(true);
+  });
+});
+
+describe('rewriteMediaHandoffRequestUri', () => {
+  it('rewrites HLS request paths to the selected gateway while preserving the asset path', () => {
+    expect(
+      rewriteMediaHandoffRequestUri('https://old.example/ipfs/bafy123/720p/segment_001.ts?token=1', {
+        cid: 'bafy123',
+        gateway: 'https://new.example/ipfs/',
+      })
+    ).toBe('https://new.example/ipfs/bafy123/720p/segment_001.ts?token=1');
+  });
+
+  it('returns empty string when the request does not belong to the active cid', () => {
+    expect(
+      rewriteMediaHandoffRequestUri('https://old.example/ipfs/other/segment_001.ts', {
+        cid: 'bafy123',
+        gateway: 'https://new.example/ipfs/',
+      })
+    ).toBe('');
+  });
+});
+
+describe('classifyMediaHandoffRequestKind', () => {
+  it('distinguishes manifest and segment requests', () => {
+    expect(classifyMediaHandoffRequestKind('https://example.com/ipfs/bafy123/index.m3u8')).toBe(
+      mediaHandoffRequestKindManifest
+    );
+    expect(classifyMediaHandoffRequestKind('https://example.com/ipfs/bafy123/720p/segment_001.ts')).toBe(
+      mediaHandoffRequestKindSegment
+    );
+  });
+});
+
+describe('isSuccessfulMediaHandoffSegmentResponse', () => {
+  it('accepts successful target-gateway segment responses', () => {
+    expect(
+      isSuccessfulMediaHandoffSegmentResponse(
+        {
+          uri: 'https://new.example/ipfs/bafy123/720p/segment_001.ts',
+        },
+        null,
+        {
+          statusCode: 200,
+        },
+        {
+          cid: 'bafy123',
+          gateway: 'https://new.example/ipfs/',
+        }
+      )
+    ).toBe(true);
+  });
+
+  it('ignores manifest requests and failed responses', () => {
+    expect(
+      isSuccessfulMediaHandoffSegmentResponse(
+        {
+          uri: 'https://new.example/ipfs/bafy123/index.m3u8',
+        },
+        null,
+        {
+          statusCode: 200,
+        },
+        {
+          cid: 'bafy123',
+          gateway: 'https://new.example/ipfs/',
+        }
+      )
+    ).toBe(false);
+
+    expect(
+      isSuccessfulMediaHandoffSegmentResponse(
+        {
+          uri: 'https://new.example/ipfs/bafy123/720p/segment_001.ts',
+        },
+        null,
+        {
+          statusCode: 404,
+        },
+        {
+          cid: 'bafy123',
+          gateway: 'https://new.example/ipfs/',
+        }
+      )
+    ).toBe(false);
+  });
+});
+
+describe('clearRecoverableMediaPlaylistExclusions', () => {
+  it('clears gateway-recoverable exclusions but keeps non-usable ones', () => {
+    const playlists = [
+      { id: '480p', excludeUntil: Date.now() + 1000, lastExcludeReason_: 'network' },
+      { id: '720p', excludeUntil: Infinity, lastExcludeReason_: 'non-usable' },
+      { id: '1080p', excludeUntil: Infinity, lastExcludeReason_: 'playlist-unchanged' },
+    ];
+
+    expect(clearRecoverableMediaPlaylistExclusions(playlists)).toBe(2);
+    expect(playlists[0]).not.toHaveProperty('excludeUntil');
+    expect(playlists[0]).not.toHaveProperty('lastExcludeReason_');
+    expect(playlists[1]).toMatchObject({
+      excludeUntil: Infinity,
+      lastExcludeReason_: 'non-usable',
+    });
+    expect(playlists[2]).not.toHaveProperty('excludeUntil');
+    expect(playlists[2]).not.toHaveProperty('lastExcludeReason_');
+  });
+});
+
+describe('resumeMediaHandoffPlayback', () => {
+  it('clears the player error, re-enables playlists, and restarts loading', () => {
+    let currentError = { code: 2 };
+    const playlistController = {
+      error: { code: 2 },
+      mainPlaylistLoader_: {
+        error: { code: 2 },
+        main: {
+          playlists: [
+            { id: '480p', excludeUntil: Date.now() + 1000, lastExcludeReason_: 'network' },
+            { id: '720p', excludeUntil: Infinity, lastExcludeReason_: 'non-usable' },
+          ],
+        },
+        load: vi.fn(),
+      },
+      mainSegmentLoader_: {
+        error: vi.fn(),
+      },
+      audioSegmentLoader_: {
+        error: vi.fn(),
+      },
+      subtitleSegmentLoader_: {
+        error: vi.fn(),
+      },
+      load: vi.fn(),
+      play: vi.fn(),
+    };
+    const player = {
+      error: vi.fn(function setOrGetError(value) {
+        if (arguments.length > 0) {
+          currentError = value;
+          return currentError;
+        }
+
+        return currentError;
+      }),
+      tech: () => ({
+        vhs: {
+          playlistController_: playlistController,
+        },
+      }),
+    };
+
+    const result = resumeMediaHandoffPlayback(player, { shouldAutoplay: false });
+
+    expect(result).toEqual({
+      didClearError: true,
+      reincludedPlaylistCount: 1,
+      didResumeLoading: true,
+    });
+    expect(player.error).toHaveBeenCalledWith(null);
+    expect(playlistController.mainPlaylistLoader_.load).toHaveBeenCalledTimes(1);
+    expect(playlistController.load).toHaveBeenCalledTimes(1);
+    expect(playlistController.play).not.toHaveBeenCalled();
+    expect(playlistController.mainSegmentLoader_.error).toHaveBeenCalledWith(null);
+  });
+
+  it('uses play() when autoplay intent should be preserved', () => {
+    const playlistController = {
+      mainPlaylistLoader_: {
+        main: {
+          playlists: [],
+        },
+        load: vi.fn(),
+      },
+      mainSegmentLoader_: {
+        error: vi.fn(),
+      },
+      load: vi.fn(),
+      play: vi.fn(),
+    };
+    const player = {
+      error: vi.fn(() => null),
+      tech: () => ({
+        vhs: {
+          playlistController_: playlistController,
+        },
+      }),
+    };
+
+    const result = resumeMediaHandoffPlayback(player, { shouldAutoplay: true });
+
+    expect(result).toEqual({
+      didClearError: false,
+      reincludedPlaylistCount: 0,
+      didResumeLoading: true,
+    });
+    expect(playlistController.mainPlaylistLoader_.load).toHaveBeenCalledTimes(1);
+    expect(playlistController.play).toHaveBeenCalledTimes(1);
+    expect(playlistController.load).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

Closes #3

同一個 CID 切換 gateway 時，原本會走完整 source switch，造成已下載的 buffer 被浪費、播放時間與播放意圖容易被打亂，也會放大前一次失敗 gateway 留下的 VHS 錯誤狀態。

這個 PR 只實作收斂後的 `v1` baseline，先滿足基礎 scenario test；延後項目另開在 `#11`。

## What

- 新增同 CID gateway 切換時的 media handoff 路徑，改用 VHS request cutover 取代完整 source reset
- 讓後續建立的 `index.m3u8`、variant `*.m3u8`、segment 請求改走新 gateway，同時保留既有 buffer 先繼續播放
- 保留播放 / 暫停意圖與播放時間，並補上前一次失敗後再次手動切換的 recovery
- handoff 期間鎖住解析度；若新 gateway 無完全相同解析度，先選最近較低，再選最近較高
- 新增 media handoff util 與對應單元測試，並補 variant playlist / resolution parsing 的測試

## Validation

- `npm test` (`20` files / `208` tests passed)
- `npm run build`
- 手動驗證：
  - 播放中切 gateway，不回 `0` 秒
  - 暫停中切 gateway，不自動播放
  - `local -> failing external -> local` 可恢復下載

## Follow-up

- `v1` 不會在 handoff 後自動把 `Auto` 放回 ABR，也沒有加入更進一步的自動 rollback / failure policy；後續追蹤在 `#11`
