### PR TITLE
fix(header): 手機版 actions 收斂成單一 gear menu

### DIFF
--- a/e2e/rwd.e2e.js
+++ b/e2e/rwd.e2e.js
@@ -23,6 +23,23 @@ async function getBox(locator) {
   return box;
 }
 
+async function openGatewayDialog(page) {
+  const directGatewayButton = page.getByTestId('gateway-button');
+
+  if (await directGatewayButton.isVisible()) {
+    await directGatewayButton.click();
+    return;
+  }
+
+  const mobileActionsButton = page.getByTestId('header-mobile-actions-button');
+  await expect(mobileActionsButton).toBeVisible();
+  await mobileActionsButton.click();
+
+  const mobileGatewayButton = page.getByTestId('header-mobile-gateway-button');
+  await expect(mobileGatewayButton).toBeVisible();
+  await mobileGatewayButton.click();
+}
+
 test.describe('Responsive Page Shell', () => {
   for (const viewport of viewportMatrix) {
     test(`${viewport.name} keeps the main shell stable`, async ({ page }) => {
@@ -286,7 +303,7 @@ test.describe('Responsive Gateway Dialog', () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await openApp(page);
 
-    await page.getByTestId('gateway-button').click();
+    await openGatewayDialog(page);
     const dialog = page.getByTestId('gateway-dialog');
     await expect(dialog).toBeVisible();
 
@@ -305,7 +322,7 @@ test.describe('Responsive Gateway Dialog', () => {
     await page.setViewportSize({ width: 1920, height: 1080 });
     await openApp(page);
 
-    await page.getByTestId('gateway-button').click();
+    await openGatewayDialog(page);
     const dialog = page.getByTestId('gateway-dialog');
     await expect(dialog).toBeVisible();
 
@@ -322,7 +339,7 @@ test.describe('Responsive Gateway Dialog', () => {
     await page.setViewportSize({ width: 1366, height: 768 });
     await openApp(page);
 
-    await page.getByTestId('gateway-button').click();
+    await openGatewayDialog(page);
     await expect(page.getByTestId('gateway-dialog')).toBeVisible();
 
     const localOption = page.getByTestId('gateway-option-local');

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -41,6 +41,8 @@ const settingsOpen = ref(false);
 const localeActionRef = ref(null);
 const localeButtonRef = ref(null);
 const localeMenuRef = ref(null);
+const mobileActionsRef = ref(null);
+const mobileActionsButtonRef = ref(null);
 const gatewayButtonRef = ref(null);
 const gatewayDialogRef = ref(null);
 const selectedGatewayId = ref(builtInGateways[0].id);
@@ -52,7 +54,10 @@ const gatewayProbeStates = ref({});
 const gatewayCooldownUntilByUrl = ref({});
 const isGatewayProbeRunning = ref(false);
 const isLocaleMenuOpen = ref(false);
+const isMobileActionsMenuOpen = ref(false);
+const isMobileLocaleListOpen = ref(false);
 const lastFocusedGatewayTrigger = ref(null);
+const pendingGatewayFocusTarget = ref(null);
 
 const localGatewayUrl = computed(() => `http://${localHost.value}:${localPort.value}/ipfs/`);
 const customGatewayPreview = computed(() => normalizeGatewayUrl(customGateway.value));
@@ -298,7 +303,9 @@ watch(settingsOpen, async (isOpen) => {
   if (typeof document === 'undefined') return;
 
   if (isOpen) {
-    lastFocusedGatewayTrigger.value = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    lastFocusedGatewayTrigger.value =
+      pendingGatewayFocusTarget.value || (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+    pendingGatewayFocusTarget.value = null;
     await nextTick();
     gatewayDialogRef.value?.focus();
     document.addEventListener('keydown', handleGatewayDialogKeydown);
@@ -308,7 +315,8 @@ watch(settingsOpen, async (isOpen) => {
   document.removeEventListener('keydown', handleGatewayDialogKeydown);
   await nextTick();
 
-  const nextFocusTarget = gatewayButtonRef.value || lastFocusedGatewayTrigger.value;
+  const nextFocusTarget =
+    (isCompactHeader.value ? mobileActionsButtonRef.value : gatewayButtonRef.value) || lastFocusedGatewayTrigger.value;
   if (nextFocusTarget && typeof nextFocusTarget.focus === 'function') {
     nextFocusTarget.focus();
   }
@@ -364,6 +372,7 @@ function toggleSidebar() {
 }
 
 function toggleLocaleMenu() {
+  closeMobileActionsMenu({ restoreFocus: false });
   isLocaleMenuOpen.value = !isLocaleMenuOpen.value;
 }
 
@@ -379,31 +388,78 @@ function closeLocaleMenu(options = {}) {
   }
 }
 
+function toggleMobileActionsMenu() {
+  if (isMobileActionsMenuOpen.value) {
+    closeMobileActionsMenu();
+    return;
+  }
+
+  closeLocaleMenu({ restoreFocus: false });
+  isMobileActionsMenuOpen.value = true;
+  isMobileLocaleListOpen.value = false;
+}
+
+function closeMobileActionsMenu(options = {}) {
+  if (!isMobileActionsMenuOpen.value && !isMobileLocaleListOpen.value) return;
+
+  isMobileActionsMenuOpen.value = false;
+  isMobileLocaleListOpen.value = false;
+
+  if (options.restoreFocus !== false) {
+    nextTick(() => {
+      mobileActionsButtonRef.value?.focus();
+    });
+  }
+}
+
+function toggleMobileLocaleList() {
+  if (!isMobileActionsMenuOpen.value) {
+    isMobileActionsMenuOpen.value = true;
+  }
+
+  isMobileLocaleListOpen.value = !isMobileLocaleListOpen.value;
+}
+
 function changeLocale(nextLocale) {
   const localeCode = typeof nextLocale === 'string' ? nextLocale : nextLocale?.target?.value;
 
   if (!localeCode) return;
   setLocale(localeCode);
   closeLocaleMenu({ restoreFocus: false });
+  closeMobileActionsMenu({ restoreFocus: false });
 }
 
 function handleDocumentPointerDown(event) {
-  if (!isLocaleMenuOpen.value) return;
-
-  if (localeActionRef.value?.contains(event.target)) {
-    return;
+  if (isLocaleMenuOpen.value && !localeActionRef.value?.contains(event.target)) {
+    closeLocaleMenu({ restoreFocus: false });
   }
 
-  closeLocaleMenu({ restoreFocus: false });
+  if (isMobileActionsMenuOpen.value && !mobileActionsRef.value?.contains(event.target)) {
+    closeMobileActionsMenu({ restoreFocus: false });
+  }
 }
 
 function handleDocumentKeydown(event) {
-  if (event.key !== 'Escape' || !isLocaleMenuOpen.value) {
+  if (event.key !== 'Escape') {
     return;
   }
 
-  event.preventDefault();
-  closeLocaleMenu();
+  if (isMobileLocaleListOpen.value) {
+    event.preventDefault();
+    isMobileLocaleListOpen.value = false;
+    return;
+  }
+
+  if (isMobileActionsMenuOpen.value) {
+    event.preventDefault();
+    closeMobileActionsMenu();
+    return;
+  }
+
+  if (isLocaleMenuOpen.value) {
+    event.preventDefault();
+    closeLocaleMenu();
+  }
 }
 
 function syncLocalFromGateway(urlStr) {
@@ -445,7 +501,9 @@ function formatGatewayEndpoint(urlStr) {
 }
 
 function openSettings() {
+  pendingGatewayFocusTarget.value = isCompactHeader.value ? mobileActionsButtonRef.value || gatewayButtonRef.value : gatewayButtonRef.value;
   closeLocaleMenu({ restoreFocus: false });
+  closeMobileActionsMenu({ restoreFocus: false });
   if (isDevMode) {
     restoreLocalGateway();
     syncLocalFromGateway(props.currentGateway);
@@ -902,7 +960,17 @@ function restoreLocalGateway() {
 
 function syncCompactHeaderViewport() {
   if (typeof window === 'undefined') return;
-  isCompactHeader.value = window.innerWidth <= 480;
+  const shouldCompact = window.innerWidth <= 640;
+
+  if (shouldCompact && isLocaleMenuOpen.value) {
+    closeLocaleMenu({ restoreFocus: false });
+  }
+
+  if (!shouldCompact && isMobileActionsMenuOpen.value) {
+    closeMobileActionsMenu({ restoreFocus: false });
+  }
+
+  isCompactHeader.value = shouldCompact;
 }
 
 onMounted(() => {
@@ -1089,6 +1157,89 @@ onBeforeUnmount(() => {
           <span class="action-btn-title">{{ t('header.actions.account.title') }}</span>
         </span>
       </button>
+    </div>
+    <div
+      ref="mobileActionsRef"
+      class="mobile-actions-shell"
+      data-testid="header-mobile-actions-shell"
+    >
+      <button
+        ref="mobileActionsButtonRef"
+        type="button"
+        class="action-btn mobile-actions-btn"
+        :aria-label="t('header.actions.mobileMenu.ariaLabel')"
+        :title="t('header.actions.mobileMenu.title')"
+        aria-haspopup="menu"
+        :aria-expanded="isMobileActionsMenuOpen ? 'true' : 'false'"
+        data-testid="header-mobile-actions-button"
+        @click="toggleMobileActionsMenu"
+      >
+        <span class="action-btn-visual mobile-actions-btn-visual" aria-hidden="true">
+          <svg class="mobile-actions-btn-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              fill="currentColor"
+              d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.73 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.49-.12-.61l-2.01-1.58zM12 15.5c-1.92 0-3.5-1.58-3.5-3.5s1.58-3.5 3.5-3.5 3.5 1.58 3.5 3.5-1.58 3.5-3.5 3.5z"
+            />
+          </svg>
+        </span>
+      </button>
+      <div
+        v-if="isMobileActionsMenuOpen"
+        class="mobile-actions-menu glass-panel"
+        role="menu"
+        :aria-label="t('header.actions.mobileMenu.label')"
+        data-testid="header-mobile-actions-menu"
+      >
+        <button
+          type="button"
+          class="mobile-actions-menu-item"
+          role="menuitem"
+          :aria-expanded="isMobileLocaleListOpen ? 'true' : 'false'"
+          data-testid="header-mobile-language-button"
+          @click="toggleMobileLocaleList"
+        >
+          <span class="mobile-actions-menu-item-copy">
+            <span class="mobile-actions-menu-item-title">{{ t('common.language') }}</span>
+            <span class="mobile-actions-menu-item-meta">{{ currentLocaleDefinition?.nativeLabel || locale }}</span>
+          </span>
+          <span class="mobile-actions-menu-item-caret" aria-hidden="true">{{ isMobileLocaleListOpen ? '▴' : '▾' }}</span>
+        </button>
+        <div
+          v-if="isMobileLocaleListOpen"
+          class="mobile-actions-locale-list"
+          data-testid="header-mobile-locale-list"
+        >
+          <button
+            v-for="option in availableLocales"
+            :key="`mobile-${option.code}`"
+            type="button"
+            class="mobile-actions-locale-item"
+            :class="{ 'is-active': locale === option.code }"
+            role="menuitemradio"
+            :aria-checked="locale === option.code ? 'true' : 'false'"
+            :data-testid="`header-mobile-locale-option-${option.code}`"
+            @click="changeLocale(option.code)"
+          >
+            <span class="mobile-actions-menu-item-copy">
+              <span class="mobile-actions-menu-item-title">{{ option.nativeLabel }}</span>
+              <span class="mobile-actions-menu-item-meta">{{ option.code }}</span>
+            </span>
+            <span v-if="locale === option.code" class="locale-menu-item-check" aria-hidden="true">✓</span>
+          </button>
+        </div>
+        <button
+          type="button"
+          class="mobile-actions-menu-item"
+          role="menuitem"
+          data-testid="header-mobile-gateway-button"
+          @click="openSettings"
+        >
+          <span class="mobile-actions-menu-item-copy">
+            <span class="mobile-actions-menu-item-title">{{ t('header.actions.gateway.label') }}</span>
+            <span class="mobile-actions-menu-item-meta">{{ currentGatewayName }}</span>
+          </span>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -1363,12 +1514,14 @@ onBeforeUnmount(() => {
 .search-area {
   flex: 1;
   max-width: 600px;
+  min-width: 0;
   display: flex;
   justify-content: center;
 }
 
 .search-bar {
   width: 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
   background: rgba(0, 0, 0, 0.3);
@@ -1392,6 +1545,7 @@ onBeforeUnmount(() => {
   font-size: 1rem;
   outline: none;
   width: 100%;
+  min-width: 0;
 }
 
 .search-bar input::placeholder {
@@ -1430,6 +1584,12 @@ onBeforeUnmount(() => {
   flex: 0 0 auto;
   min-width: 0;
   justify-content: flex-end;
+}
+
+.mobile-actions-shell {
+  position: relative;
+  display: none;
+  flex: 0 0 auto;
 }
 
 .locale-action-shell {
@@ -1734,6 +1894,111 @@ onBeforeUnmount(() => {
   height: 18px;
 }
 
+.mobile-actions-btn {
+  width: 46px;
+  min-width: 46px;
+  max-width: 46px;
+  gap: 0;
+  padding: 0;
+  justify-content: center;
+}
+
+.mobile-actions-btn .action-btn-copy {
+  display: none;
+}
+
+.mobile-actions-btn-visual {
+  color: rgba(255, 255, 255, 0.82);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+}
+
+.mobile-actions-btn-icon {
+  width: 19px;
+  height: 19px;
+}
+
+.mobile-actions-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(196px, calc(100vw - 18px));
+  display: grid;
+  gap: 4px;
+  padding: 6px;
+  border-radius: 16px;
+  z-index: 140;
+}
+
+.mobile-actions-menu-item,
+.mobile-actions-locale-item {
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  border-radius: 12px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.mobile-actions-menu-item:hover,
+.mobile-actions-menu-item:focus-visible,
+.mobile-actions-locale-item:hover,
+.mobile-actions-locale-item:focus-visible {
+  background: rgba(255, 255, 255, 0.05);
+  outline: none;
+}
+
+.mobile-actions-locale-item.is-active {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.mobile-actions-menu-item-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.mobile-actions-menu-item-title {
+  font-size: 0.84rem;
+  font-weight: 600;
+  line-height: 1.15;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.mobile-actions-menu-item-meta {
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.48);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-actions-menu-item-caret {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.78rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.mobile-actions-locale-list {
+  display: grid;
+  gap: 4px;
+  padding-top: 0;
+}
+
 .icon-btn {
   background: transparent;
   border: none;
@@ -1793,9 +2058,32 @@ onBeforeUnmount(() => {
     font-size: 0.88rem;
   }
 }
+
+@media (max-width: 640px) {
+  .header {
+    padding: 0 14px;
+  }
+  .search-area {
+    margin: 0 8px;
+  }
+  .search-bar {
+    padding: 6px 10px;
+  }
+  .search-actions {
+    margin-left: 6px;
+    gap: 2px;
+  }
+  .actions-area {
+    display: none;
+  }
+  .mobile-actions-shell {
+    display: flex;
+  }
+}
+
 @media (max-width: 480px) {
   .header {
-    padding: 0 12px;
+    padding: 0 10px;
   }
   .logo-area {
     gap: 10px;
@@ -1807,10 +2095,10 @@ onBeforeUnmount(() => {
     display: none; /* Only show logo icon on tiny screens */
   }
   .search-area {
-    margin: 0 6px;
+    margin: 0 4px;
   }
   .search-bar {
-    padding: 6px 10px;
+    padding: 6px 8px;
   }
   .search-bar input {
     font-size: 0.85rem;
@@ -1818,27 +2106,20 @@ onBeforeUnmount(() => {
   .search-submit-btn {
     margin-left: 4px;
   }
-  .actions-area {
-    --header-locale-min-width: 88px;
-    --header-locale-max-width: 160px;
-    --header-gateway-min-width: 96px;
-    --header-gateway-max-width: 176px;
-  }
-  .locale-action-shell {
-    min-width: var(--header-locale-min-width);
-    max-width: var(--header-locale-max-width);
-  }
-  .locale-btn {
-    padding: 4px 6px;
-  }
   .locale-menu {
     min-width: 170px;
     right: -8px;
   }
-  .gateway-btn {
-    min-width: var(--header-gateway-min-width);
-    max-width: var(--header-gateway-max-width);
-    padding: 4px 6px;
+  .mobile-actions-btn {
+    flex: 0 0 44px;
+    width: 44px;
+    min-width: 44px;
+    max-width: 44px;
+  }
+  .mobile-actions-btn-visual {
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
   }
   .action-btn-visual {
     --action-chip-radius: 10px;
@@ -1850,33 +2131,39 @@ onBeforeUnmount(() => {
     width: 16px;
     height: 16px;
   }
+  .mobile-actions-btn-icon {
+    width: 18px;
+    height: 18px;
+  }
+  .mobile-actions-menu {
+    width: min(184px, calc(100vw - 16px));
+  }
 }
 
 @media (max-width: 375px) {
-  .locale-action-shell {
-    flex: 0 0 46px;
-    min-width: 46px;
-    max-width: 46px;
+  .mobile-actions-btn {
+    flex: 0 0 42px;
+    width: 42px;
+    min-width: 42px;
+    max-width: 42px;
   }
-  .locale-btn {
-    gap: 0;
-    padding: 0;
-    justify-content: center;
+  .mobile-actions-btn-visual {
+    width: 30px;
+    height: 30px;
+    border-radius: 999px;
   }
-  .locale-btn .action-btn-copy {
-    display: none;
+  .action-btn-visual {
+    width: 28px;
+    height: 28px;
   }
-  .gateway-btn {
-    flex: 0 0 46px;
-    width: 46px;
-    min-width: 46px;
-    max-width: 46px;
-    gap: 0;
-    padding: 0;
-    justify-content: center;
+  .gateway-btn-icon,
+  .locale-btn-icon,
+  .mobile-actions-btn-icon {
+    width: 17px;
+    height: 17px;
   }
-  .gateway-btn .action-btn-copy {
-    display: none;
+  .mobile-actions-menu {
+    width: min(176px, calc(100vw - 14px));
   }
 }
 

--- a/src/components/header_search_actions.spec.js
+++ b/src/components/header_search_actions.spec.js
@@ -34,19 +34,31 @@ describe('Header search action button', () => {
     expect(template).toContain('data-testid="header-locale-button"');
     expect(template).toContain('class="action-btn locale-btn"');
     expect(template).toContain('class="locale-menu glass-panel"');
+    expect(template).toContain('data-testid="header-mobile-actions-shell"');
+    expect(template).toContain('data-testid="header-mobile-actions-button"');
+    expect(template).toContain('data-testid="header-mobile-actions-menu"');
+    expect(template).toContain('data-testid="header-mobile-language-button"');
+    expect(template).toContain('data-testid="header-mobile-gateway-button"');
 
     expect(script).toContain("import { useI18n } from '../i18n';");
     expect(script).toContain("const { availableLocales, locale, setLocale, t } = useI18n();");
     expect(script).toContain('const searchInputRef = ref(null);');
     expect(script).toContain('const isSearchQueryEmpty = computed(() => searchQuery.value.trim().length === 0);');
+    expect(script).toContain('const shouldCompact = window.innerWidth <= 640;');
+    expect(script).toContain('const isMobileActionsMenuOpen = ref(false);');
+    expect(script).toContain('const isMobileLocaleListOpen = ref(false);');
     expect(script).toContain('function focusSearchInput() {');
     expect(script).toContain('async function clearSearchQuery() {');
     expect(script).toContain('function toggleLocaleMenu() {');
+    expect(script).toContain('function toggleMobileActionsMenu() {');
+    expect(script).toContain('function closeMobileActionsMenu(options = {}) {');
+    expect(script).toContain('function toggleMobileLocaleList() {');
     expect(script).toContain('function closeLocaleMenu(options = {}) {');
     expect(script).toContain('function changeLocale(nextLocale) {');
     expect(script).toContain("searchQuery.value = '';");
     expect(script).toContain('await nextTick();');
     expect(script).toContain('focusSearchInput();');
+    expect(script).not.toContain('openInfoJsonDialog');
     expect(script).not.toContain('navigator.clipboard');
     expect(script).not.toContain('pasteSearchQueryFromClipboard');
     expect(script).not.toContain('onSearchAction');
@@ -57,6 +69,13 @@ describe('Header search action button', () => {
     expect(style).toContain('.locale-action-shell');
     expect(style).toContain('.locale-btn');
     expect(style).toContain('.locale-menu');
+    expect(style).toContain('.mobile-actions-shell');
+    expect(style).toContain('.mobile-actions-menu');
+    expect(style).toContain('.mobile-actions-locale-list');
+    expect(style).toContain('max-width: 600px;\n  min-width: 0;');
+    expect(style).toContain('@media (max-width: 640px)');
+    expect(style).toContain('.actions-area {\n    display: none;');
+    expect(style).toContain('.mobile-actions-shell {\n    display: flex;');
   });
 });
 

--- a/src/i18n/messages/en.js
+++ b/src/i18n/messages/en.js
@@ -32,6 +32,11 @@ export default Object.freeze({
       },
     },
     actions: {
+      mobileMenu: {
+        label: 'Quick actions',
+        title: 'Open quick actions',
+        ariaLabel: 'Open quick actions',
+      },
       gateway: {
         label: 'Gateway',
         ariaLabel: 'Switch gateway. Current gateway: {gateway}',

--- a/src/i18n/messages/ja.js
+++ b/src/i18n/messages/ja.js
@@ -32,6 +32,11 @@ export default Object.freeze({
       },
     },
     actions: {
+      mobileMenu: {
+        label: 'その他の操作',
+        title: 'その他の操作を開く',
+        ariaLabel: 'その他の操作を開く',
+      },
       gateway: {
         label: 'ゲートウェイ',
         ariaLabel: 'ゲートウェイを切り替え。現在: {gateway}',

--- a/src/i18n/messages/zh-TW.js
+++ b/src/i18n/messages/zh-TW.js
@@ -32,6 +32,11 @@ export default Object.freeze({
       },
     },
     actions: {
+      mobileMenu: {
+        label: '更多操作',
+        title: '開啟更多操作',
+        ariaLabel: '開啟更多操作',
+      },
       gateway: {
         label: '網關',
         ariaLabel: '切換網關，目前為 {gateway}',


### PR DESCRIPTION
## Why
手機版 header 在約 `393px` 到較大尺寸手機 portrait 寬度下，右上角 actions 會擠壓搜尋框，甚至讓文字外溢。這張 PR 只處理 mobile header 的空間分配，讓搜尋框優先、右上角操作收斂。

## What
- 將手機版 header 在 `<=640px` 收斂成單一 gear / overflow menu。
- 保留語系切換與 gateway 設定入口，並讓它們改由 mobile menu 開啟。
- 補上 search area 的 `min-width: 0` 與對應 responsive / contract / e2e coverage。

## Validation
- `npm test -- src/components/header_search_actions.spec.js`
- `npm run build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:47137/ipfs-hls-test/ npm run test:e2e -- --grep "Responsive Gateway Dialog"`

## Scope
- Closes #13
- 不包含播放器截圖
- 不包含 info.json / sidecar metadata authoring