### PR TITLE
fix(metadata): keep draft dialog metadata in sync while pristine

### DIFF
--- a/src/components/InfoJsonDialog.vue
+++ b/src/components/InfoJsonDialog.vue
@@ -9,8 +9,10 @@ import {
 } from '../utils/subtitles';
 import {
   buildInfoJsonPayload,
+  createVideoInfoDraftFormSnapshot,
+  createVideoInfoDraftFormState,
   createDefaultVideoInfo,
-  formatUploadDate,
+  isVideoInfoDraftFormPristine,
   stringifyInfoJson,
 } from '../utils/videoInfo';
 
@@ -40,8 +42,9 @@ const activeTab = ref('metadata');
 const feedbackMessage = ref('');
 const localVideoFile = ref(null);
 const localSubtitleTracks = ref([]);
-const form = reactive(createFormState(props.initialVideoInfo));
+const form = reactive(createVideoInfoDraftFormState(props.initialVideoInfo));
 const processorForm = reactive(createProcessorFormState());
+const lastSyncedFormSnapshot = ref(createVideoInfoDraftFormSnapshot(form));
 
 let feedbackTimeout = 0;
 
@@ -156,6 +159,22 @@ watch(
 );
 
 watch(
+  () => props.initialVideoInfo,
+  (nextVideoInfo) => {
+    if (!props.open) {
+      return;
+    }
+
+    if (!isVideoInfoDraftFormPristine(form, lastSyncedFormSnapshot.value)) {
+      return;
+    }
+
+    syncForm(nextVideoInfo);
+  },
+  { deep: true }
+);
+
+watch(
   hasGeneratedInfoJson,
   (available) => {
     if (!available) {
@@ -181,21 +200,6 @@ onBeforeUnmount(() => {
   clearSubtitleTracks({ silent: true });
 });
 
-function createFormState(videoInfo = createDefaultVideoInfo()) {
-  const source = videoInfo && typeof videoInfo === 'object' ? videoInfo : createDefaultVideoInfo();
-
-  return {
-    id: source.id || '',
-    title: source.title || '',
-    uploader: source.uploader || '',
-    channelId: source.channelId || '',
-    uploadDate: formatUploadDate(source.uploadDate || ''),
-    description: source.description || '',
-    tags: Array.isArray(source.tags) ? source.tags.join(', ') : '',
-    categories: Array.isArray(source.categories) ? source.categories.join(', ') : '',
-  };
-}
-
 function createProcessorFormState() {
   return {
     selectedResolutions: [...defaultProcessorResolutionSelection],
@@ -205,7 +209,9 @@ function createProcessorFormState() {
 }
 
 function syncForm(videoInfo) {
-  Object.assign(form, createFormState(videoInfo));
+  const nextFormState = createVideoInfoDraftFormState(videoInfo);
+  Object.assign(form, nextFormState);
+  lastSyncedFormSnapshot.value = createVideoInfoDraftFormSnapshot(nextFormState);
 }
 
 function parseListInput(value) {
@@ -372,7 +378,8 @@ function closeDialog() {
 }
 
 function clearForm() {
-  syncForm(createDefaultVideoInfo());
+  Object.assign(form, createVideoInfoDraftFormState(createDefaultVideoInfo()));
+  lastSyncedFormSnapshot.value = null;
   clearFeedback();
   nextTick(() => {
     titleInputRef.value?.focus();

--- a/src/components/info_json_dialog.spec.js
+++ b/src/components/info_json_dialog.spec.js
@@ -25,12 +25,14 @@ describe('InfoJsonDialog tabbed draft contract', () => {
     expect(script).toContain("const activeTab = ref('metadata');");
     expect(script).toContain("const dialogTabIds = Object.freeze(['metadata', 'subtitles', 'video']);");
     expect(script).toContain("const dialogTabs = computed(() =>");
+    expect(script).toContain('const lastSyncedFormSnapshot = ref(createVideoInfoDraftFormSnapshot(form));');
     expect(script).toContain("const effectiveIncludeInfoJson = computed(");
     expect(script).toContain("const effectiveIncludeSubtitleManifest = computed(");
     expect(script).toContain("function buildLocalVideoProcessorDraft(file, options = {}) {");
     expect(script).toContain('function setActiveTab(tabId) {');
     expect(script).toContain("async function handleSubtitleSelection(event) {");
     expect(script).toContain("function handleVideoSelection(event) {");
+    expect(script).toContain('isVideoInfoDraftFormPristine(form, lastSyncedFormSnapshot.value)');
     expect(script).not.toContain("const localAvatarFile = ref(null);");
     expect(script).not.toContain("function handleAvatarSelection(event) {");
 

--- a/src/utils/videoInfo.js
+++ b/src/utils/videoInfo.js
@@ -14,6 +14,16 @@ const defaultVideoInfo = Object.freeze({
 
 const descriptionUrlPattern = /\b(?:https?:\/\/|www\.)[^\s<]+/gi;
 const descriptionHashtagPattern = /(^|[\s([{<"'`「『（【])#([\p{L}\p{N}_][\p{L}\p{N}\p{M}_-]*)/gu;
+const draftFormFieldNames = Object.freeze([
+  'id',
+  'title',
+  'uploader',
+  'channelId',
+  'uploadDate',
+  'description',
+  'tags',
+  'categories',
+]);
 
 export function createDefaultVideoInfo() {
   return {
@@ -37,6 +47,43 @@ export function normalizeVideoInfo(payload = {}) {
     resolution: normalizeString(payload.resolution),
     fps: normalizeFps(payload.fps),
   };
+}
+
+export function createVideoInfoDraftFormState(videoInfo = createDefaultVideoInfo()) {
+  const source = videoInfo && typeof videoInfo === 'object' ? videoInfo : createDefaultVideoInfo();
+
+  return {
+    id: source.id || '',
+    title: source.title || '',
+    uploader: source.uploader || '',
+    channelId: source.channelId || '',
+    uploadDate: formatUploadDate(source.uploadDate || ''),
+    description: source.description || '',
+    tags: Array.isArray(source.tags) ? source.tags.join(', ') : '',
+    categories: Array.isArray(source.categories) ? source.categories.join(', ') : '',
+  };
+}
+
+export function createVideoInfoDraftFormSnapshot(formState = {}) {
+  return {
+    id: normalizeString(formState.id),
+    title: normalizeString(formState.title),
+    uploader: normalizeString(formState.uploader),
+    channelId: normalizeString(formState.channelId),
+    uploadDate: normalizeString(formState.uploadDate),
+    description: normalizeString(formState.description),
+    tags: normalizeString(formState.tags),
+    categories: normalizeString(formState.categories),
+  };
+}
+
+export function isVideoInfoDraftFormPristine(formState = {}, lastSyncedSnapshot = null) {
+  if (!lastSyncedSnapshot || typeof lastSyncedSnapshot !== 'object') {
+    return false;
+  }
+
+  const currentSnapshot = createVideoInfoDraftFormSnapshot(formState);
+  return draftFormFieldNames.every((fieldName) => currentSnapshot[fieldName] === lastSyncedSnapshot[fieldName]);
 }
 
 export function buildInfoJsonPayload(payload = {}) {

--- a/src/utils/videoInfo.spec.js
+++ b/src/utils/videoInfo.spec.js
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildInfoJsonPayload,
+  createVideoInfoDraftFormSnapshot,
+  createVideoInfoDraftFormState,
   createDefaultVideoInfo,
   extractDescriptionHashtags,
   fetchVideoInfo,
   formatRelativeUploadTime,
   formatUploadDate,
   formatUploadDateTooltip,
+  isVideoInfoDraftFormPristine,
   linkifyDescription,
   normalizeVideoInfo,
   stringifyInfoJson,
@@ -69,6 +72,65 @@ describe('normalizeVideoInfo', () => {
       resolution: '1920x1080',
       fps: 30,
     });
+  });
+});
+
+describe('createVideoInfoDraftFormState', () => {
+  it('maps loaded metadata into the dialog form shape', () => {
+    expect(
+      createVideoInfoDraftFormState({
+        id: 'demo-id',
+        title: 'Demo Title',
+        uploader: 'AstraStream',
+        channelId: 'channel-id',
+        uploadDate: '20260325',
+        description: 'desc',
+        tags: ['IPFS', 'Web3'],
+        categories: ['Technology'],
+      })
+    ).toEqual({
+      id: 'demo-id',
+      title: 'Demo Title',
+      uploader: 'AstraStream',
+      channelId: 'channel-id',
+      uploadDate: '2026-03-25',
+      description: 'desc',
+      tags: 'IPFS, Web3',
+      categories: 'Technology',
+    });
+  });
+});
+
+describe('isVideoInfoDraftFormPristine', () => {
+  it('returns true when the current form still matches the last synced snapshot', () => {
+    const formState = createVideoInfoDraftFormState({
+      title: 'Demo Title',
+      uploader: 'AstraStream',
+      uploadDate: '20260325',
+    });
+    const snapshot = createVideoInfoDraftFormSnapshot(formState);
+
+    expect(isVideoInfoDraftFormPristine(formState, snapshot)).toBe(true);
+  });
+
+  it('returns false after the user changes the form or when no synced snapshot exists', () => {
+    const formState = createVideoInfoDraftFormState({
+      title: 'Demo Title',
+      uploader: 'AstraStream',
+      uploadDate: '20260325',
+    });
+    const snapshot = createVideoInfoDraftFormSnapshot(formState);
+
+    expect(
+      isVideoInfoDraftFormPristine(
+        {
+          ...formState,
+          title: 'Edited Title',
+        },
+        snapshot
+      )
+    ).toBe(false);
+    expect(isVideoInfoDraftFormPristine(formState, null)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why
素材草稿 Dialog 原本只會在開啟當下把 `currentVideoInfo` 帶進 metadata 表單。當 metadata 在 Dialog 已開啟後才載入或切換影片後更新時，表單可能停在空白或舊值，讓 sidecar 草稿整理流程中斷。

## What
- 為 metadata draft form 加入 last-synced snapshot 與 pristine 判斷
- 只有在使用者尚未手動修改表單時，才在 Dialog 開啟期間自動同步最新 `currentVideoInfo`
- `Clear form` 後停止自動回填，避免覆蓋接下來的手動輸入
- 將表單 state / snapshot helper 抽到 `videoInfo` util，並補上 util 與 component tests

## Validation
- `npm test`
- `npm run build`

## Risks
- 這次自動同步只涵蓋 metadata form；字幕與影片草稿仍維持目前的 session-local 行為
- `vite build` 仍有既有 chunk size warning：`dist/assets/index-B-scq8Jj.js` 約 `966.37 kB`

Closes #20