### PR TITLE
fix(video-info): 移除上傳者資訊列的 Channel ID 前綴

### DIFF
--- a/src/components/VideoInfo.vue
+++ b/src/components/VideoInfo.vue
@@ -95,7 +95,7 @@ const overflowActionOrder = [shareActionId, subtitleActionId, downloadActionId];
 const displayUploader = computed(() => props.videoInfo.uploader || 'IPFS Node');
 const displayChannelText = computed(() => {
   if (props.videoInfo.channelId) {
-    return `Channel ID: ${props.videoInfo.channelId}`;
+    return props.videoInfo.channelId;
   }
 
   if (props.videoInfo.categories.length > 0) {

--- a/src/components/video_layout.spec.js
+++ b/src/components/video_layout.spec.js
@@ -332,6 +332,15 @@ describe('VideoInfo layout contract', () => {
     expect(style).toContain('.stats-panel:hover .stats-tooltip');
   });
 
+  it('shows the uploader secondary text without a Channel ID prefix while keeping metadata labels unchanged', () => {
+    const descriptor = readDescriptor(new URL('./VideoInfo.vue', import.meta.url));
+    const script = descriptor.scriptSetup?.content || '';
+
+    expect(script).toContain('return props.videoInfo.channelId;');
+    expect(script).not.toContain('Channel ID: ${props.videoInfo.channelId}');
+    expect(script).toContain("{ label: 'Channel ID', value: props.videoInfo.channelId }");
+  });
+
   it('moves download into an overflow menu and lets share collapse before like or dislike', () => {
     const descriptor = readDescriptor(new URL('./VideoInfo.vue', import.meta.url));
     const template = descriptor.template?.content || '';


### PR DESCRIPTION
## 為什麼

目前上傳者資訊列會顯示 `Channel ID: <值>`，前綴資訊重複，
讓這一列看起來比較冗。這次調整的目標是保留頻道值本身，
讓畫面更乾淨，同時不影響其他仍需要 `Channel ID` 標籤的地方。

## 這次改了什麼

- 調整 `VideoInfo` 的 `displayChannelText`，有 `channelId` 時只顯示值本身
- 保留 `channelId` 缺漏時的既有 fallback 行為
- 補上 contract test，確認 metadata grid 的 `Channel ID` 標籤維持不變

## 驗證

- `npm test -- src/components/video_layout.spec.js`
- `npm test`
- `npm run build`

## 風險與範圍

- 這次只調整上傳者資訊列的次級文字
- 不包含 metadata grid 與表單欄位的 `Channel ID` 文案調整

Closes #35
