### PR TITLE
feature(touch): 鎖定觸控裝置的頁面縮放

### DIFF
--- a/e2e/touch_zoom_lock.e2e.js
+++ b/e2e/touch_zoom_lock.e2e.js
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+async function openApp(page, { touchDevice = false } = {}) {
+  await page.route('https://images.unsplash.com/**', (route) => route.abort());
+  await page.route('https://api.dicebear.com/**', (route) => route.abort());
+
+  if (touchDevice) {
+    await page.addInitScript(() => {
+      Object.defineProperty(Navigator.prototype, 'maxTouchPoints', {
+        configurable: true,
+        get() {
+          return 5;
+        },
+      });
+    });
+  }
+
+  await page.goto('./', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('app-header')).toBeVisible();
+}
+
+test.describe('Touch zoom lock', () => {
+  test('locks viewport zoom on touch-capable devices', async ({ page }) => {
+    await openApp(page, {
+      touchDevice: true,
+    });
+
+    const viewportContent = await page.locator('meta[name="viewport"]').getAttribute('content');
+    expect(viewportContent).toBe('width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no');
+
+    const touchMoveResult = await page.evaluate(() => {
+      const event = new Event('touchmove', {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, 'touches', {
+        configurable: true,
+        value: [{ identifier: 1 }, { identifier: 2 }],
+      });
+
+      const dispatched = document.dispatchEvent(event);
+
+      return {
+        defaultPrevented: event.defaultPrevented,
+        dispatched,
+      };
+    });
+
+    expect(touchMoveResult.defaultPrevented).toBe(true);
+    expect(touchMoveResult.dispatched).toBe(false);
+  });
+
+  test('keeps non-touch devices on the default viewport rules', async ({ page }) => {
+    await openApp(page);
+
+    const viewportContent = await page.locator('meta[name="viewport"]').getAttribute('content');
+    expect(viewportContent).toBe('width=device-width, initial-scale=1.0');
+
+    const touchMoveResult = await page.evaluate(() => {
+      const event = new Event('touchmove', {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, 'touches', {
+        configurable: true,
+        value: [{ identifier: 1 }, { identifier: 2 }],
+      });
+
+      const dispatched = document.dispatchEvent(event);
+
+      return {
+        defaultPrevented: event.defaultPrevented,
+        dispatched,
+      };
+    });
+
+    expect(touchMoveResult.defaultPrevented).toBe(false);
+    expect(touchMoveResult.dispatched).toBe(true);
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import { createI18n } from './i18n';
+import { lockTouchDeviceZoom } from './utils/touchZoomLock';
 
 import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
@@ -9,6 +10,12 @@ import 'video.js/dist/video-js.css';
 window.videojs = videojs;
 
 import 'videojs-hls-quality-selector';
+
+lockTouchDeviceZoom({
+  window,
+  document,
+  navigator,
+});
 
 const app = createApp(App);
 const i18n = createI18n({

--- a/src/utils/touchZoomLock.js
+++ b/src/utils/touchZoomLock.js
@@ -1,0 +1,144 @@
+const VIEWPORT_SELECTOR = 'meta[name="viewport"]';
+const SCALE_TOKENS = new Set(['initial-scale', 'minimum-scale', 'maximum-scale', 'user-scalable']);
+const PINCH_GESTURE_EVENTS = ['gesturestart', 'gesturechange', 'gestureend'];
+const NON_PASSIVE_LISTENER = { passive: false };
+
+function getViewportTokenKey(token) {
+  const [rawKey = ''] = token.split('=');
+  return rawKey.trim().toLowerCase();
+}
+
+function readMediaQueryMatch(windowRef, query) {
+  if (!windowRef || typeof windowRef.matchMedia !== 'function') {
+    return false;
+  }
+
+  try {
+    return Boolean(windowRef.matchMedia(query)?.matches);
+  } catch {
+    return false;
+  }
+}
+
+function ensureViewportMeta(documentRef) {
+  if (!documentRef?.querySelector) {
+    return null;
+  }
+
+  let viewportMeta = documentRef.querySelector(VIEWPORT_SELECTOR);
+  if (viewportMeta) {
+    return viewportMeta;
+  }
+
+  if (!documentRef.createElement || !documentRef.head?.appendChild) {
+    return null;
+  }
+
+  viewportMeta = documentRef.createElement('meta');
+  viewportMeta.setAttribute('name', 'viewport');
+  documentRef.head.appendChild(viewportMeta);
+  return viewportMeta;
+}
+
+function preventIfCancelable(event) {
+  if (event?.cancelable) {
+    event.preventDefault();
+  }
+}
+
+export function isTouchCapableDevice({ navigator: navigatorRef, window: windowRef } = {}) {
+  if (typeof navigatorRef?.maxTouchPoints === 'number') {
+    return navigatorRef.maxTouchPoints > 0;
+  }
+
+  return readMediaQueryMatch(windowRef, '(any-pointer: coarse)') || readMediaQueryMatch(windowRef, '(pointer: coarse)');
+}
+
+export function buildLockedViewportContent(content = '') {
+  const tokens = content
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+  const preservedTokens = [];
+  const preservedKeys = new Set();
+
+  for (const token of tokens) {
+    const key = getViewportTokenKey(token);
+
+    if (SCALE_TOKENS.has(key) || preservedKeys.has(key)) {
+      continue;
+    }
+
+    preservedKeys.add(key);
+    preservedTokens.push(token);
+  }
+
+  if (!preservedKeys.has('width')) {
+    preservedTokens.unshift('width=device-width');
+  }
+
+  return [...preservedTokens, 'initial-scale=1', 'minimum-scale=1', 'maximum-scale=1', 'user-scalable=no'].join(', ');
+}
+
+export function applyTouchViewportLock(documentRef) {
+  const viewportMeta = ensureViewportMeta(documentRef);
+
+  if (!viewportMeta) {
+    return null;
+  }
+
+  const currentContent = viewportMeta.getAttribute('content') || '';
+  viewportMeta.setAttribute('content', buildLockedViewportContent(currentContent));
+  return viewportMeta;
+}
+
+export function shouldPreventTouchZoom(event) {
+  if (!event) {
+    return false;
+  }
+
+  if (typeof event.scale === 'number' && event.scale !== 1) {
+    return true;
+  }
+
+  return typeof event.touches?.length === 'number' && event.touches.length > 1;
+}
+
+export function lockTouchDeviceZoom({
+  window: windowRef = globalThis.window,
+  document: documentRef = globalThis.document,
+  navigator: navigatorRef = globalThis.navigator,
+} = {}) {
+  if (!isTouchCapableDevice({ navigator: navigatorRef, window: windowRef })) {
+    return () => {};
+  }
+
+  applyTouchViewportLock(documentRef);
+
+  if (!documentRef?.addEventListener) {
+    return () => {};
+  }
+
+  const handleTouchMove = (event) => {
+    if (shouldPreventTouchZoom(event)) {
+      preventIfCancelable(event);
+    }
+  };
+  const handleGesture = (event) => {
+    preventIfCancelable(event);
+  };
+
+  documentRef.addEventListener('touchmove', handleTouchMove, NON_PASSIVE_LISTENER);
+
+  for (const eventName of PINCH_GESTURE_EVENTS) {
+    documentRef.addEventListener(eventName, handleGesture);
+  }
+
+  return () => {
+    documentRef.removeEventListener('touchmove', handleTouchMove, NON_PASSIVE_LISTENER);
+
+    for (const eventName of PINCH_GESTURE_EVENTS) {
+      documentRef.removeEventListener(eventName, handleGesture);
+    }
+  };
+}

--- a/src/utils/touchZoomLock.spec.js
+++ b/src/utils/touchZoomLock.spec.js
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyTouchViewportLock,
+  buildLockedViewportContent,
+  isTouchCapableDevice,
+  lockTouchDeviceZoom,
+  shouldPreventTouchZoom,
+} from './touchZoomLock';
+
+function createMetaElement(initialContent = '') {
+  return {
+    attributes: {
+      content: initialContent,
+      name: 'viewport',
+    },
+    getAttribute(name) {
+      return this.attributes[name] ?? null;
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = value;
+    },
+  };
+}
+
+function createFakeDocument({ metaContent = 'width=device-width, initial-scale=1.0', includeMeta = true } = {}) {
+  let viewportMeta = includeMeta ? createMetaElement(metaContent) : null;
+  const listeners = new Map();
+
+  return {
+    head: {
+      appendChild(node) {
+        viewportMeta = node;
+      },
+    },
+    querySelector(selector) {
+      if (selector === 'meta[name="viewport"]') {
+        return viewportMeta;
+      }
+
+      return null;
+    },
+    createElement() {
+      return createMetaElement();
+    },
+    addEventListener(type, handler, options) {
+      const handlers = listeners.get(type) || [];
+      handlers.push({ handler, options });
+      listeners.set(type, handlers);
+    },
+    removeEventListener(type, handler) {
+      const handlers = listeners.get(type) || [];
+      listeners.set(
+        type,
+        handlers.filter((entry) => entry.handler !== handler)
+      );
+    },
+    __getListeners(type) {
+      return listeners.get(type) || [];
+    },
+    __getViewportMeta() {
+      return viewportMeta;
+    },
+  };
+}
+
+function createFakeEvent(overrides = {}) {
+  return {
+    cancelable: true,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    ...overrides,
+  };
+}
+
+describe('isTouchCapableDevice', () => {
+  it('prefers maxTouchPoints when available', () => {
+    expect(
+      isTouchCapableDevice({
+        navigator: { maxTouchPoints: 5 },
+        window: {},
+      })
+    ).toBe(true);
+  });
+
+  it('falls back to coarse pointer media queries when touch points are unavailable', () => {
+    expect(
+      isTouchCapableDevice({
+        navigator: {},
+        window: {
+          matchMedia(query) {
+            return {
+              matches: query === '(any-pointer: coarse)',
+            };
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('keeps non-touch devices unlocked', () => {
+    expect(
+      isTouchCapableDevice({
+        navigator: { maxTouchPoints: 0 },
+        window: {
+          matchMedia() {
+            return {
+              matches: false,
+            };
+          },
+        },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('buildLockedViewportContent', () => {
+  it('preserves non-scale tokens while forcing a locked zoom viewport', () => {
+    expect(buildLockedViewportContent('width=device-width, initial-scale=2, viewport-fit=cover, user-scalable=yes')).toBe(
+      'width=device-width, viewport-fit=cover, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no'
+    );
+  });
+
+  it('adds a sane default width token when the source viewport is missing one', () => {
+    expect(buildLockedViewportContent('viewport-fit=cover')).toBe(
+      'width=device-width, viewport-fit=cover, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no'
+    );
+  });
+});
+
+describe('shouldPreventTouchZoom', () => {
+  it('blocks multitouch and scaled move events while allowing single-touch scroll', () => {
+    expect(shouldPreventTouchZoom(createFakeEvent({ touches: [{}, {}] }))).toBe(true);
+    expect(shouldPreventTouchZoom(createFakeEvent({ scale: 1.2 }))).toBe(true);
+    expect(shouldPreventTouchZoom(createFakeEvent({ touches: [{}] }))).toBe(false);
+  });
+});
+
+describe('applyTouchViewportLock', () => {
+  it('creates a viewport meta tag when one does not exist', () => {
+    const documentRef = createFakeDocument({
+      includeMeta: false,
+    });
+
+    const viewportMeta = applyTouchViewportLock(documentRef);
+
+    expect(viewportMeta?.getAttribute('content')).toBe(
+      'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no'
+    );
+    expect(documentRef.__getViewportMeta()).toBe(viewportMeta);
+  });
+});
+
+describe('lockTouchDeviceZoom', () => {
+  it('locks the viewport and registers pinch guards on touch-capable devices', () => {
+    const documentRef = createFakeDocument();
+    const cleanup = lockTouchDeviceZoom({
+      document: documentRef,
+      navigator: { maxTouchPoints: 2 },
+      window: {},
+    });
+
+    expect(documentRef.__getViewportMeta()?.getAttribute('content')).toBe(
+      'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no'
+    );
+    expect(documentRef.__getListeners('touchmove')).toHaveLength(1);
+    expect(documentRef.__getListeners('gesturestart')).toHaveLength(1);
+    expect(documentRef.__getListeners('gesturechange')).toHaveLength(1);
+    expect(documentRef.__getListeners('gestureend')).toHaveLength(1);
+
+    const multitouchMove = createFakeEvent({
+      touches: [{}, {}],
+    });
+    documentRef.__getListeners('touchmove')[0].handler(multitouchMove);
+    expect(multitouchMove.defaultPrevented).toBe(true);
+
+    const singleTouchMove = createFakeEvent({
+      touches: [{}],
+    });
+    documentRef.__getListeners('touchmove')[0].handler(singleTouchMove);
+    expect(singleTouchMove.defaultPrevented).toBe(false);
+
+    cleanup();
+
+    expect(documentRef.__getListeners('touchmove')).toHaveLength(0);
+    expect(documentRef.__getListeners('gesturestart')).toHaveLength(0);
+  });
+
+  it('does not change non-touch devices', () => {
+    const documentRef = createFakeDocument();
+    const cleanup = lockTouchDeviceZoom({
+      document: documentRef,
+      navigator: { maxTouchPoints: 0 },
+      window: {
+        matchMedia() {
+          return {
+            matches: false,
+          };
+        },
+      },
+    });
+
+    expect(documentRef.__getViewportMeta()?.getAttribute('content')).toBe('width=device-width, initial-scale=1.0');
+    expect(documentRef.__getListeners('touchmove')).toHaveLength(0);
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Why
- 觸控裝置上誤觸雙指縮放會讓頁面跑版，Issue #39 要求在所有具觸控能力的裝置上鎖定頁面縮放。

## What
- 新增 touch zoom lock utility，依觸控能力判定是否套用縮放鎖定
- 只在觸控裝置上強制 viewport scale 固定，並攔截常見 pinch/gesture 縮放事件
- 補上單元測試與 Playwright E2E，並回歸既有 responsive 驗證

## Validation
- npm test
- npx playwright test e2e/rwd.e2e.js e2e/touch_zoom_lock.e2e.js

## Risk
- 此需求刻意接受觸控裝置上無法手動放大閱讀的產品取捨
- 判定依據為瀏覽器回報的觸控能力，而非螢幕尺寸

Closes #39
