### PR TITLE
feature(header): 支援主 Icon 快速回首頁

### DIFF
--- a/e2e/rwd.e2e.js
+++ b/e2e/rwd.e2e.js
@@ -384,6 +384,27 @@ test.describe('Responsive Page Shell', () => {
     await expect(page.getByTestId('sidebar-backdrop')).toHaveCount(0);
     await expect.poll(readSidebarOpacity).toBeLessThanOrEqual(0.05);
   });
+
+  test('returns from history to home when the header logo button is activated', async ({ page }) => {
+    await page.setViewportSize({ width: 1366, height: 768 });
+    await openApp(page);
+
+    await page.getByTestId('header-sidebar-toggle').click();
+    await expect(page.getByTestId('sidebar-item-history')).toBeVisible();
+    await page.getByTestId('sidebar-item-history').click();
+
+    await expect(page.getByTestId('history-page')).toBeVisible();
+    await expect(page.getByTestId('history-empty')).toBeVisible();
+    await expect(page.getByTestId('watch-page')).toHaveCount(0);
+
+    const homeButton = page.getByTestId('header-home-button');
+    await expect(homeButton).toBeVisible();
+    await homeButton.focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByTestId('history-page')).toHaveCount(0);
+    await expect(page.getByTestId('watch-page')).toBeVisible();
+  });
 });
 
 test.describe('Custom Player Controls', () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -976,6 +976,7 @@ watch(
 <template>
   <Header
     @search="onSearchCid"
+    @home-click="onViewSelect('home')"
     :current-gateway="currentGateway"
     :current-cid="currentCid"
     :current-load-sequence="currentLoadSequence"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -37,7 +37,7 @@ const props = defineProps({
   },
   sidebarOpen: { type: Boolean, default: false },
 });
-const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar']);
+const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar', 'home-click']);
 const { availableLocales, locale, setLocale, t } = useI18n();
 
 const searchQuery = ref('');
@@ -390,6 +390,14 @@ async function clearSearchQuery() {
 
 function toggleSidebar() {
   emit('toggle-sidebar');
+}
+
+function onLogoClick() {
+  closeLocaleMenu({ restoreFocus: false });
+  closeMobileActionsMenu({ restoreFocus: false });
+  closeSettings();
+  closeInfoJsonDialog();
+  emit('home-click');
 }
 
 function toggleLocaleMenu() {
@@ -1053,10 +1061,17 @@ onBeforeUnmount(() => {
       >
         <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
       </button>
-      <div class="logo">
+      <button
+        type="button"
+        class="logo"
+        :aria-label="t('sidebar.menu.home')"
+        :title="t('sidebar.menu.home')"
+        data-testid="header-home-button"
+        @click="onLogoClick"
+      >
         <span class="logo-icon">▲</span>
         <span class="logo-text">Astra<span class="neon-text">Stream</span></span>
-      </div>
+      </button>
     </div>
 
     <div class="search-area" data-testid="header-search-area">
@@ -1552,6 +1567,24 @@ onBeforeUnmount(() => {
   font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0.5px;
+  padding: 4px 8px;
+  margin: -4px -8px;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.logo:hover,
+.logo:focus-visible {
+  background: var(--interactive-hover);
+}
+
+.logo:focus-visible {
+  outline: none;
 }
 
 .logo-icon {

--- a/src/components/header_search_actions.spec.js
+++ b/src/components/header_search_actions.spec.js
@@ -18,6 +18,10 @@ describe('Header search action button', () => {
     const script = descriptor.scriptSetup?.content || '';
     const style = getStyleContent(descriptor);
 
+    expect(template).toContain('data-testid="header-home-button"');
+    expect(template).toContain('@click="onLogoClick"');
+    expect(template).toContain(":aria-label=\"t('sidebar.menu.home')\"");
+    expect(template).toContain(":title=\"t('sidebar.menu.home')\"");
     expect(template).toContain('ref="searchInputRef"');
     expect(template).toContain('@keyup.enter="onSearch"');
     expect(template).toContain('class="search-actions"');
@@ -46,6 +50,7 @@ describe('Header search action button', () => {
     expect(script).toContain("import InfoJsonDialog from './InfoJsonDialog.vue';");
     expect(script).toContain("import { useI18n } from '../i18n';");
     expect(script).toContain("const { availableLocales, locale, setLocale, t } = useI18n();");
+    expect(script).toContain("const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar', 'home-click']);");
     expect(script).toContain('const searchInputRef = ref(null);');
     expect(script).toContain('const isSearchQueryEmpty = computed(() => searchQuery.value.trim().length === 0);');
     expect(script).toContain('const shouldCompact = window.innerWidth <= 640;');
@@ -54,6 +59,8 @@ describe('Header search action button', () => {
     expect(script).toContain('const isInfoJsonDialogOpen = ref(false);');
     expect(script).toContain('function focusSearchInput() {');
     expect(script).toContain('async function clearSearchQuery() {');
+    expect(script).toContain('function onLogoClick() {');
+    expect(script).toContain("emit('home-click');");
     expect(script).toContain('function toggleLocaleMenu() {');
     expect(script).toContain('function toggleMobileActionsMenu() {');
     expect(script).toContain('function closeMobileActionsMenu(options = {}) {');
@@ -75,6 +82,8 @@ describe('Header search action button', () => {
     expect(style).toContain('.locale-action-shell');
     expect(style).toContain('.locale-btn');
     expect(style).toContain('.locale-menu');
+    expect(style).toContain('.logo:hover,');
+    expect(style).toContain('.logo:focus-visible {');
     expect(style).toContain('.info-json-btn');
     expect(style).toContain('.mobile-actions-shell');
     expect(style).toContain('.mobile-actions-menu');
@@ -116,13 +125,15 @@ describe('Sidebar toggle contract', () => {
     expect(appTemplate).toContain('class="sidebar-backdrop"');
     expect(appTemplate).toContain('data-testid="sidebar-backdrop"');
     expect(appTemplate).toContain(':sidebar-open="isSidebarOpen"');
+    expect(appTemplate).toContain("@home-click=\"onViewSelect('home')\"");
     expect(appTemplate).toContain('@toggle-sidebar="toggleSidebar"');
     expect(appTemplate).toContain('<Sidebar :active-view="activeView" :open="isSidebarOpen" @view-select="onViewSelect" />');
 
     expect(headerScript).toContain("sidebarOpen: { type: Boolean, default: false },");
-    expect(headerScript).toContain("const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar']);");
+    expect(headerScript).toContain("const emit = defineEmits(['search', 'gateway-change', 'gateway-candidates-change', 'toggle-sidebar', 'home-click']);");
     expect(headerScript).toContain('function toggleSidebar() {');
     expect(headerTemplate).toContain('aria-controls="app-sidebar"');
+    expect(headerTemplate).toContain('data-testid="header-home-button"');
     expect(headerTemplate).toContain('data-testid="header-sidebar-toggle"');
     expect(headerTemplate).toContain('@click="toggleSidebar"');
     expect(headerTemplate).toContain(":aria-expanded=\"sidebarOpen ? 'true' : 'false'\"");


### PR DESCRIPTION
## 為什麼
- 目前從觀看紀錄返回首頁只能依賴側邊欄，Header 左上主 Icon 缺少常見的回首頁能力
- 使用者切到觀看紀錄後，缺少更直覺且可預期的主導覽入口

## 這次改了什麼
- 將 Header 左上 Logo 改為可互動的首頁按鈕，補上無障礙名稱、title 與 focus/hover 狀態
- 重用既有 `onViewSelect('home')` 流程，從觀看紀錄返回首頁時延續目前已載入的播放內容與狀態
- 補上 Header 結構契約測試與從觀看紀錄回首頁的 Playwright 驗證

## 驗證
- `npx vitest run src/components/header_search_actions.spec.js`
- `npx playwright test e2e/rwd.e2e.js --grep "returns from history to home when the header logo button is activated"`

Closes #44