### PR TITLE
feature(saved): 新增手動儲存影片清單

### DIFF
--- a/e2e/rwd.e2e.js
+++ b/e2e/rwd.e2e.js
@@ -682,6 +682,7 @@ test.describe('Responsive Video Actions', () => {
     await expect(actions).not.toHaveClass(/actions-wrapped/);
     await expect(page.getByTestId('video-info-like-button')).toBeVisible();
     await expect(page.getByTestId('video-info-dislike-button')).toBeVisible();
+    await expect(page.getByTestId('video-info-save-button')).toBeVisible();
     await expect(page.getByTestId('video-info-share-button')).toBeVisible();
     await expect(page.getByTestId('video-info-creator-text')).toBeVisible();
 
@@ -691,6 +692,7 @@ test.describe('Responsive Video Actions', () => {
     await page.getByTestId('video-info-overflow-trigger').click();
     await expect(page.getByTestId('video-info-overflow-menu')).toBeVisible();
     await expect(page.getByTestId('video-info-overflow-item-download')).toBeVisible();
+    await expect(page.getByTestId('video-info-overflow-item-save')).toHaveCount(0);
     await expect(page.getByTestId('video-info-overflow-item-share')).toHaveCount(0);
   });
 
@@ -703,6 +705,7 @@ test.describe('Responsive Video Actions', () => {
     await expect(actions).toHaveClass(/actions-wrapped/);
     await expect(page.getByTestId('video-info-like-button')).toBeVisible();
     await expect(page.getByTestId('video-info-dislike-button')).toBeVisible();
+    await expect(page.getByTestId('video-info-save-button')).toHaveCount(0);
     await expect(page.getByTestId('video-info-share-button')).toHaveCount(0);
     await expect(page.getByTestId('video-info-creator-text')).toBeVisible();
     await expect(page.getByTestId('video-info-follow-button')).toBeVisible();
@@ -716,6 +719,7 @@ test.describe('Responsive Video Actions', () => {
 
     await page.getByTestId('video-info-overflow-trigger').click();
     await expect(page.getByTestId('video-info-overflow-menu')).toBeVisible();
+    await expect(page.getByTestId('video-info-overflow-item-save')).toBeVisible();
     await expect(page.getByTestId('video-info-overflow-item-share')).toBeVisible();
     await expect(page.getByTestId('video-info-overflow-item-download')).toBeVisible();
   });

--- a/e2e/series_playlist.e2e.js
+++ b/e2e/series_playlist.e2e.js
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test';
 
+const gatewayStorageKey = 'ipfs-hls-selected-gateway';
 const historyStorageKey = 'ipfs-hls-watch-history';
+const savedStorageKey = 'ipfs-hls-saved-videos';
 const localGatewayBase = 'http://127.0.0.1:8080/ipfs/';
 const tinyPosterPng = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wn6zk8AAAAASUVORK5CYII=',
@@ -100,7 +102,7 @@ function buildSeriesRoutesFromEpisodes(seriesCid, episodes = [], title = 'Demo S
   return routeMap;
 }
 
-function buildSingleRoutes(singleCid) {
+function buildSingleRoutes(singleCid, overrides = {}) {
   return {
     [`${localGatewayBase}${singleCid}/playlist.json`]: {
       status: 404,
@@ -123,9 +125,9 @@ function buildSingleRoutes(singleCid) {
     [`${localGatewayBase}${singleCid}/info.json`]: {
       contentType: 'application/json',
       body: JSON.stringify({
-        title: 'Standalone Episode',
-        uploader: 'Single Team',
-        duration_string: '00:05',
+        title: overrides.title || 'Standalone Episode',
+        uploader: overrides.uploader || 'Single Team',
+        duration_string: overrides.durationString || '00:05',
       }),
     },
     [`${localGatewayBase}${singleCid}/subtitles.json`]: {
@@ -171,6 +173,12 @@ async function openApp(page, url) {
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   await expect(page.getByTestId('app-header')).toBeVisible();
   await expect(page.getByTestId('main-content')).toBeVisible();
+}
+
+async function openSavedVideos(page) {
+  await page.getByTestId('header-sidebar-toggle').click();
+  await page.getByTestId('sidebar-item-library').click();
+  await expect(page.getByTestId('saved-page')).toBeVisible();
 }
 
 test.describe('Series playlist flow', () => {
@@ -272,5 +280,119 @@ test.describe('Series playlist flow', () => {
     await expect(page.getByTestId('series-playlist-item-ep05')).toHaveClass(/is-selected/);
     await expect(page.getByTestId('series-playlist-item-ep05')).toContainText('Series Episode 5');
     await expect(page.getByTestId('series-playlist-item-ep05')).not.toContainText('Wrong Sidecar Title 5');
+  });
+
+  test('keeps saved videos ordered by manual save time and lets the watch button toggle removal', async ({ page }) => {
+    const firstCid = 'bafy-save-first';
+    const secondCid = 'bafy-save-second';
+
+    await mountMockGateway(page, {
+      ...buildSingleRoutes(firstCid, {
+        title: 'Saved Video One',
+        uploader: 'Saved Team One',
+        durationString: '00:11',
+      }),
+      ...buildSingleRoutes(secondCid, {
+        title: 'Saved Video Two',
+        uploader: 'Saved Team Two',
+        durationString: '00:22',
+      }),
+    });
+    await page.addInitScript(({ historyKey, savedKey, gatewayKey, gatewayUrl, resetMarker }) => {
+      if (!window.sessionStorage.getItem(resetMarker)) {
+        window.localStorage.removeItem(historyKey);
+        window.localStorage.removeItem(savedKey);
+        window.sessionStorage.setItem(resetMarker, '1');
+      }
+
+      window.localStorage.setItem(gatewayKey, gatewayUrl);
+    }, {
+      historyKey: historyStorageKey,
+      savedKey: savedStorageKey,
+      gatewayKey: gatewayStorageKey,
+      gatewayUrl: localGatewayBase,
+      resetMarker: 'series-playlist-saved-videos-reset',
+    });
+    await page.setViewportSize({ width: 1366, height: 900 });
+
+    await openApp(page, `./?cid=${firstCid}`);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Saved Video One');
+    await page.getByTestId('video-info-save-button').click();
+    await expect(page.getByTestId('video-info-save-button')).toHaveClass(/is-active/);
+
+    await openApp(page, `./?cid=${secondCid}`);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Saved Video Two');
+    await page.getByTestId('video-info-save-button').click();
+    await expect(page.getByTestId('video-info-save-button')).toHaveClass(/is-active/);
+
+    await openSavedVideos(page);
+    await expect(page.locator('[data-testid^="saved-item-"]')).toHaveCount(2);
+
+    const savedBeforeRemoval = await page.locator('[data-testid^="saved-item-"]').evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('data-testid'))
+    );
+    expect(savedBeforeRemoval).toEqual([`saved-item-${secondCid}`, `saved-item-${firstCid}`]);
+
+    await openApp(page, `./?cid=${firstCid}`);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Saved Video One');
+    await expect(page.getByTestId('video-info-save-button')).toHaveClass(/is-active/);
+    await page.getByTestId('video-info-save-button').click();
+    await expect(page.getByTestId('video-info-save-button')).not.toHaveClass(/is-active/);
+
+    const savedAfterToggleRemove = await page.evaluate((storageKey) => {
+      const rawValue = window.localStorage.getItem(storageKey);
+      return rawValue ? JSON.parse(rawValue) : [];
+    }, savedStorageKey);
+    expect(savedAfterToggleRemove.map((item) => item.cid)).toEqual([secondCid]);
+    expect(savedAfterToggleRemove).toHaveLength(1);
+
+    await openSavedVideos(page);
+    await expect(page.locator('[data-testid^="saved-item-"]')).toHaveCount(1);
+    await expect(page.getByTestId(`saved-item-${firstCid}`)).toHaveCount(0);
+
+    await openApp(page, `./?cid=${secondCid}`);
+    await openSavedVideos(page);
+    await expect(page.locator('[data-testid^="saved-item-"]')).toHaveCount(1);
+    await expect(page.getByTestId(`saved-item-${secondCid}`)).toBeVisible();
+  });
+
+  test('saves the selected series episode instead of the playlist cid and keeps watch history untouched', async ({ page }) => {
+    const seriesCid = 'bafy-series-save-demo';
+
+    await mountMockGateway(page, buildSeriesRoutes(seriesCid));
+    await page.addInitScript(({ historyKey, savedKey, gatewayKey, gatewayUrl }) => {
+      window.localStorage.removeItem(historyKey);
+      window.localStorage.removeItem(savedKey);
+      window.localStorage.setItem(gatewayKey, gatewayUrl);
+    }, {
+      historyKey: historyStorageKey,
+      savedKey: savedStorageKey,
+      gatewayKey: gatewayStorageKey,
+      gatewayUrl: localGatewayBase,
+    });
+    await page.setViewportSize({ width: 1366, height: 900 });
+    await openApp(page, `./?cid=${seriesCid}`);
+
+    await page.getByTestId('series-playlist-item-ep02').click();
+    await page.getByTestId('video-info-save-button').click();
+
+    const historyValue = await page.evaluate((storageKey) => window.localStorage.getItem(storageKey), historyStorageKey);
+    expect(historyValue).toBe(null);
+
+    const savedItems = await page.evaluate((storageKey) => {
+      const rawValue = window.localStorage.getItem(storageKey);
+      return rawValue ? JSON.parse(rawValue) : [];
+    }, savedStorageKey);
+
+    expect(savedItems).toHaveLength(1);
+    expect(savedItems[0].cid).toBe('bafy-episode-02');
+    expect(savedItems[0].seriesCid).toBe(seriesCid);
+    expect(savedItems[0].episodePath).toBe('ep02');
+    expect(savedItems[0].gateway).toBe(localGatewayBase);
+
+    await openSavedVideos(page);
+    await page.getByTestId('saved-item-bafy-episode-02').getByRole('button').first().click();
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Series Episode 2');
+    await expect(page.getByTestId('series-playlist-item-ep02')).toHaveClass(/is-selected/);
   });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import Header from './components/Header.vue';
 import HistoryPage from './components/HistoryPage.vue';
 import RecommendationsPage from './components/RecommendationsPage.vue';
+import SavedVideosPage from './components/SavedVideosPage.vue';
 import SeriesPlaylistPage from './components/SeriesPlaylistPage.vue';
 import Sidebar from './components/Sidebar.vue';
 import WatchPage from './components/WatchPage.vue';
@@ -39,6 +40,11 @@ import {
   removeHistoryEntry,
   upsertHistoryEntry,
 } from './utils/history';
+import {
+  readStoredSavedVideos,
+  removeSavedVideoEntry,
+  upsertSavedVideoEntry,
+} from './utils/savedVideos';
 import {
   createDefaultSubtitlePreference,
   mergeSubtitleTracks,
@@ -80,15 +86,18 @@ const currentStartTime = ref(0);
 const currentShouldAutoplay = ref(false);
 const currentCid = ref('');
 const currentGateway = ref(DEFAULT_GATEWAY);
+const preferredGateway = ref(DEFAULT_GATEWAY);
 const currentLoadSequence = ref(0);
 const activeView = ref('home');
 const historyItems = ref([]);
+const savedItems = ref([]);
 const isSidebarOpen = ref(false);
 const sidecarGatewayCandidates = ref([]);
 const currentHistoryAllowsReadyState = ref(true);
 const hasCurrentPlaybackStarted = ref(false);
 const isSeriesMode = computed(() => currentSourceMode.value === 'series');
 const shouldShowSeriesPlaylist = computed(() => ['series', 'series-error'].includes(currentSourceMode.value));
+const isCurrentVideoSaved = computed(() => Boolean(findSavedEntry(currentCid.value)));
 const currentSelectedSeriesEpisode = computed(() => {
   if (currentEpisodeId.value) {
     const matchedEpisodeById = currentSeriesEpisodes.value.find((episode) => episode.id === currentEpisodeId.value);
@@ -366,6 +375,7 @@ async function loadSourceFromCid(sourceCid, gateway, startTime = 0, options = {}
     updateUrl = true,
     shouldAutoplay = false,
     preferredEpisodePath = '',
+    persistGatewaySelection = true,
   } = options;
   const nextGateway = resolveGateway(gateway || readConfiguredGateway());
   const requestSeq = ++sourceRequestSeq;
@@ -374,7 +384,10 @@ async function loadSourceFromCid(sourceCid, gateway, startTime = 0, options = {}
   currentGateway.value = nextGateway;
   currentSeriesPlaylistLoading.value = true;
   currentSeriesError.value = '';
-  persistGateway(nextGateway, window);
+  if (persistGatewaySelection) {
+    preferredGateway.value = nextGateway;
+    persistGateway(nextGateway, window);
+  }
   status.value = '正在檢查內容入口...';
 
   const playlistResult = await fetchPlaylistManifest(normalizedSourceCid, nextGateway);
@@ -399,6 +412,7 @@ async function loadSourceFromCid(sourceCid, gateway, startTime = 0, options = {}
       updateUrl: false,
       shouldAutoplay,
       allowReadyStateHistory: false,
+      persistGatewaySelection,
       sourceCid: normalizedSourceCid,
       seriesEpisode: selectedEpisode,
     });
@@ -428,6 +442,7 @@ async function loadSourceFromCid(sourceCid, gateway, startTime = 0, options = {}
       updateUrl: false,
       shouldAutoplay,
       allowReadyStateHistory: true,
+      persistGatewaySelection,
       sourceCid: normalizedSourceCid,
     });
     if (updateUrl) {
@@ -456,7 +471,11 @@ function syncFromUrl() {
   const { cid, time } = parsePlayerParams(window.location.search);
   const prevGateway = currentGateway.value;
   const storedGateway = readConfiguredGateway();
-  const nextGateway = storedGateway || prevGateway || DEFAULT_GATEWAY;
+  const nextGateway = storedGateway || preferredGateway.value || prevGateway || DEFAULT_GATEWAY;
+
+  if (nextGateway !== preferredGateway.value) {
+    preferredGateway.value = nextGateway;
+  }
 
   if (nextGateway !== currentGateway.value) {
     currentGateway.value = nextGateway;
@@ -517,6 +536,7 @@ onMounted(() => {
   currentSubtitleSelection.value =
     typeof window === 'undefined' ? createDefaultSubtitlePreference() : readStoredSubtitlePreference(window);
   refreshHistory();
+  refreshSavedVideos();
   startUrlSync();
   syncFromUrl();
   startHistorySync();
@@ -542,11 +562,13 @@ function onGatewayChange(gateway) {
       updateUrl: true,
       shouldAutoplay: snapshot.isPlaying,
       preferredEpisodePath: currentEpisodePath.value,
+      persistGatewaySelection: true,
     });
     return;
   }
 
   currentGateway.value = nextGateway;
+  preferredGateway.value = nextGateway;
   persistGateway(nextGateway, window);
 }
 
@@ -606,6 +628,7 @@ function loadVideo(cid, gateway, startTime = 0, options = {}) {
     updateUrl = true,
     shouldAutoplay = false,
     allowReadyStateHistory = true,
+    persistGatewaySelection = true,
     sourceCid = cid,
     seriesEpisode = null,
   } = options;
@@ -626,7 +649,10 @@ function loadVideo(cid, gateway, startTime = 0, options = {}) {
   currentSourceCid.value = sourceCid;
   currentGateway.value = nextGateway;
   currentLoadSequence.value += 1;
-  persistGateway(nextGateway, window);
+  if (persistGatewaySelection) {
+    preferredGateway.value = nextGateway;
+    persistGateway(nextGateway, window);
+  }
   status.value = '正在連線至網關...';
 
   if (seriesEpisode) {
@@ -696,6 +722,7 @@ function selectSeriesEpisode(episode) {
     updateUrl: false,
     shouldAutoplay: false,
     allowReadyStateHistory: false,
+    persistGatewaySelection: false,
     sourceCid: currentSourceCid.value,
     seriesEpisode: episode,
   });
@@ -719,6 +746,7 @@ function onGatewayFallbackRequest(payload = {}) {
     updateUrl: false,
     shouldAutoplay: payload.shouldAutoplay === true,
     allowReadyStateHistory: currentSourceMode.value === 'single',
+    persistGatewaySelection: false,
     sourceCid: currentSourceCid.value || cid,
     seriesEpisode: currentSelectedSeriesEpisode.value,
   });
@@ -826,6 +854,10 @@ function refreshHistory() {
   historyItems.value = readStoredHistory(window);
 }
 
+function refreshSavedVideos() {
+  savedItems.value = readStoredSavedVideos(window);
+}
+
 function findHistoryEntry(cid) {
   const normalizedCid = typeof cid === 'string' ? cid.trim() : '';
   if (!normalizedCid) return null;
@@ -833,8 +865,19 @@ function findHistoryEntry(cid) {
   return historyItems.value.find((item) => item.cid === normalizedCid) || null;
 }
 
+function findSavedEntry(cid) {
+  const normalizedCid = typeof cid === 'string' ? cid.trim() : '';
+  if (!normalizedCid) return null;
+
+  return savedItems.value.find((item) => item.cid === normalizedCid) || null;
+}
+
 function persistHistoryEntry(entry) {
   historyItems.value = upsertHistoryEntry(entry, window);
+}
+
+function persistSavedVideoEntry(entry) {
+  savedItems.value = upsertSavedVideoEntry(entry, window);
 }
 
 function persistCurrentHistory(options = {}) {
@@ -889,15 +932,19 @@ function stopHistorySync() {
 }
 
 function onViewSelect(nextView) {
-  if (nextView === 'history') {
+  if (nextView === 'history' || nextView === 'saved') {
     persistCurrentHistory();
-    refreshHistory();
-    activeView.value = 'history';
+    if (nextView === 'history') {
+      refreshHistory();
+    } else {
+      refreshSavedVideos();
+    }
+    activeView.value = nextView;
     closeSidebar();
     return;
   }
 
-  if (activeView.value === 'history' && currentSourceCid.value) {
+  if ((activeView.value === 'history' || activeView.value === 'saved') && currentSourceCid.value) {
     const currentHistoryEntry = findHistoryEntry(currentCid.value);
     const resumeTime =
       Number.isFinite(currentHistoryEntry?.progressSeconds) && currentHistoryEntry.progressSeconds > 0
@@ -939,6 +986,52 @@ function onHistoryRemove(cid) {
 
 function onHistoryClear() {
   historyItems.value = clearStoredHistory(window);
+}
+
+function onSaveCurrentVideo() {
+  const cid = currentCid.value.trim();
+  if (!cid) return;
+
+  if (findSavedEntry(cid)) {
+    savedItems.value = removeSavedVideoEntry(cid, window);
+    return;
+  }
+
+  persistSavedVideoEntry({
+    cid,
+    ...buildCurrentHistoryContext(),
+    title: currentVideoInfo.value.title,
+    uploader: currentVideoInfo.value.uploader,
+    posterUrl: currentHistoryPosterUrl.value,
+    gateway: preferredGateway.value || currentGateway.value,
+    durationString: currentVideoInfo.value.durationString,
+    savedAt: Date.now(),
+  });
+}
+
+function onSavedSelect(item) {
+  if (!item?.cid) return;
+
+  const targetGateway = item.gateway || preferredGateway.value || currentGateway.value;
+
+  if (item.seriesCid && item.episodePath) {
+    void loadSourceFromCid(item.seriesCid, targetGateway, 0, {
+      updateUrl: true,
+      shouldAutoplay: false,
+      preferredEpisodePath: item.episodePath,
+    });
+  } else {
+    void loadSourceFromCid(item.cid, targetGateway, 0, {
+      updateUrl: true,
+      shouldAutoplay: false,
+    });
+  }
+
+  activeView.value = 'home';
+}
+
+function onSavedRemove(cid) {
+  savedItems.value = removeSavedVideoEntry(cid, window);
 }
 
 function onPlaybackSnapshot(snapshot) {
@@ -1004,6 +1097,13 @@ watch(
           @clear="onHistoryClear"
         />
       </template>
+      <template v-else-if="activeView === 'saved'">
+        <SavedVideosPage
+          :items="savedItems"
+          @select="onSavedSelect"
+          @remove="onSavedRemove"
+        />
+      </template>
       <template v-else>
         <WatchPage
           :cid="currentCid"
@@ -1019,11 +1119,13 @@ watch(
           :imported-subtitles="currentImportedSubtitleTracks"
           :start-time="currentStartTime"
           :should-autoplay="currentShouldAutoplay"
+          :is-saved="isCurrentVideoSaved"
           :video-info="currentVideoInfo"
           @status-update="onStatusUpdate"
           @gateway-fallback-request="onGatewayFallbackRequest"
           @levels-loaded="onLevelsLoaded"
           @playback-snapshot="onPlaybackSnapshot"
+          @save-current-video="onSaveCurrentVideo"
           @subtitle-import="onSubtitleImport"
           @subtitle-remove="onSubtitleRemove"
           @subtitle-selection-change="onSubtitleSelectionChange"

--- a/src/components/SavedVideosPage.vue
+++ b/src/components/SavedVideosPage.vue
@@ -1,0 +1,329 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  items: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits(['select', 'remove']);
+
+const previewItems = computed(() =>
+  props.items.map((item) => ({
+    ...item,
+    displayTitle: item.title || formatFallbackTitle(item.cid),
+    displayUploader: item.uploader || 'IPFS Node',
+    savedAtLabel: formatSavedAt(item.savedAt),
+    gatewayLabel: formatGatewayLabel(item.gateway),
+  }))
+);
+
+function handleSelect(item) {
+  emit('select', item);
+}
+
+function handleRemove(cid) {
+  emit('remove', cid);
+}
+
+function formatFallbackTitle(cid) {
+  if (!cid) return 'Unknown CID';
+  if (cid.length <= 16) return cid;
+  return `${cid.slice(0, 8)}...${cid.slice(-6)}`;
+}
+
+function formatGatewayLabel(gateway) {
+  if (!gateway) return 'Gateway 未記錄';
+
+  try {
+    const parsed = new URL(gateway);
+    return parsed.hostname || parsed.host || gateway;
+  } catch (_) {
+    return gateway;
+  }
+}
+
+function formatSavedAt(value) {
+  const timestamp = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    return '剛剛儲存';
+  }
+
+  const diffMs = Math.max(0, Date.now() - timestamp);
+  const minuteMs = 60 * 1000;
+  const hourMs = 60 * minuteMs;
+  const dayMs = 24 * hourMs;
+
+  if (diffMs < minuteMs) return '剛剛儲存';
+  if (diffMs < hourMs) return `${Math.floor(diffMs / minuteMs)} 分鐘前儲存`;
+  if (diffMs < dayMs) return `${Math.floor(diffMs / hourMs)} 小時前儲存`;
+  return `${Math.floor(diffMs / dayMs)} 天前儲存`;
+}
+</script>
+
+<template>
+  <section class="saved-page" data-testid="saved-page">
+    <div class="saved-header">
+      <div class="saved-copy">
+        <h2>已儲存影片</h2>
+        <p class="subtitle">你手動儲存的影片會保留在本機列表，不會被後續觀看歷史自動洗掉。</p>
+      </div>
+    </div>
+
+    <div v-if="previewItems.length === 0" class="saved-empty glass-panel" data-testid="saved-empty">
+      <p class="saved-empty-title">還沒有已儲存影片</p>
+      <p class="saved-empty-text">先在觀看頁按下儲存，這裡就會出現你想稍後回看的內容。</p>
+    </div>
+
+    <div v-else class="saved-list" data-testid="saved-list">
+      <article
+        v-for="item in previewItems"
+        :key="item.cid"
+        class="saved-item glass-panel"
+        :data-testid="`saved-item-${item.cid}`"
+      >
+        <button type="button" class="saved-item-main" @click="handleSelect(item)">
+          <div class="saved-thumb">
+            <img v-if="item.posterUrl" :src="item.posterUrl" :alt="item.displayTitle" />
+            <div v-else class="saved-thumb-fallback">{{ item.displayTitle.slice(0, 1) }}</div>
+            <div v-if="item.durationString" class="saved-duration">{{ item.durationString }}</div>
+          </div>
+
+          <div class="saved-body">
+            <div class="saved-state-row">
+              <span class="saved-status-badge">已儲存</span>
+              <span class="saved-open-label">開啟影片</span>
+            </div>
+            <h3 class="saved-title">{{ item.displayTitle }}</h3>
+            <p class="saved-uploader">{{ item.displayUploader }}</p>
+            <p class="saved-time">{{ item.savedAtLabel }}</p>
+            <div class="saved-meta">
+              <span>{{ item.gatewayLabel }}</span>
+            </div>
+          </div>
+        </button>
+
+        <button type="button" class="saved-remove" @click="handleRemove(item.cid)">移除</button>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.saved-page {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 0 0 0 16px;
+  padding: 12px 16px 24px 0;
+}
+
+.saved-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.saved-copy h2 {
+  font-size: 1.5rem;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  line-height: 1.55;
+  max-width: 720px;
+}
+
+.saved-empty {
+  padding: 28px;
+  border-radius: 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.saved-empty-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.saved-empty-text {
+  color: var(--text-secondary);
+  max-width: 48ch;
+  line-height: 1.6;
+}
+
+.saved-list {
+  display: grid;
+  gap: 12px;
+}
+
+.saved-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 20px;
+}
+
+.saved-item-main {
+  display: flex;
+  align-items: stretch;
+  gap: 16px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  min-width: 0;
+  text-align: left;
+}
+
+.saved-thumb {
+  position: relative;
+  width: 220px;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at top left, rgba(0, 210, 255, 0.22), transparent 38%),
+    linear-gradient(135deg, rgba(8, 10, 18, 0.95), rgba(28, 31, 52, 0.9));
+  flex-shrink: 0;
+}
+
+.saved-thumb img,
+.saved-thumb-fallback {
+  width: 100%;
+  height: 100%;
+}
+
+.saved-thumb img {
+  object-fit: cover;
+  display: block;
+}
+
+.saved-thumb-fallback {
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.saved-duration {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.68);
+  font-size: 0.78rem;
+}
+
+.saved-body {
+  min-width: 0;
+  display: grid;
+  align-content: center;
+  gap: 8px;
+}
+
+.saved-state-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.saved-status-badge,
+.saved-open-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  min-height: 30px;
+  padding: 6px 11px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.saved-status-badge {
+  border: 1px solid rgba(255, 213, 89, 0.28);
+  background: rgba(255, 213, 89, 0.12);
+  color: #ffd976;
+}
+
+.saved-open-label {
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.saved-title {
+  font-size: 1.08rem;
+  line-height: 1.35;
+}
+
+.saved-uploader,
+.saved-time {
+  color: var(--text-secondary);
+}
+
+.saved-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.saved-remove {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(255, 255, 255, 0.78);
+  border-radius: 999px;
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.saved-remove:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+@media (max-width: 1024px) {
+  .saved-item {
+    grid-template-columns: 1fr;
+  }
+
+  .saved-remove {
+    justify-self: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .saved-page {
+    margin-left: 0;
+    padding: 12px 16px 24px;
+  }
+
+  .saved-header,
+  .saved-item-main {
+    flex-direction: column;
+  }
+
+  .saved-thumb {
+    width: 100%;
+  }
+
+  .saved-state-row {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -24,7 +24,7 @@ const worktreeName = __APP_WORKTREE__;
 const menuItems = computed(() => [
   { id: 'home', label: t('sidebar.menu.home'), targetView: 'home', icon: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' },
   { id: 'explore', label: t('sidebar.menu.explore'), targetView: '', icon: 'M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z' },
-  { id: 'library', label: t('sidebar.menu.library'), targetView: '', icon: 'M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8 12.5v-9l6 4.5-6 4.5z' },
+  { id: 'library', label: t('sidebar.menu.library'), targetView: 'saved', icon: 'M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8 12.5v-9l6 4.5-6 4.5z' },
   { id: 'history', label: t('sidebar.menu.history'), targetView: 'history', icon: 'M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z' },
 ]);
 

--- a/src/components/VideoInfo.vue
+++ b/src/components/VideoInfo.vue
@@ -21,6 +21,10 @@ const props = defineProps({
   cid: { type: String, default: '' },
   avatarUrl: { type: String, default: '' },
   ipfsBaseUrl: { type: String, default: '' },
+  isSaved: {
+    type: Boolean,
+    default: false,
+  },
   subtitles: {
     type: Array,
     default: () => [],
@@ -51,7 +55,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['subtitle-import', 'subtitle-remove', 'subtitle-selection-change']);
+const emit = defineEmits(['save-current-video', 'subtitle-import', 'subtitle-remove', 'subtitle-selection-change']);
 
 const shareDialogRef = ref(null);
 const shareUrlInputRef = ref(null);
@@ -74,6 +78,7 @@ const creatorTextMeasureRef = ref(null);
 const subscribeButtonRef = ref(null);
 const actionsRef = ref(null);
 const actionGroupRef = ref(null);
+const saveMeasureRef = ref(null);
 const shareMeasureRef = ref(null);
 const moreMenuRef = ref(null);
 const hiddenActionIds = ref([]);
@@ -86,11 +91,12 @@ let syncInProgress = false;
 let syncPending = false;
 let shareCopySuccessTimeout = 0;
 
+const saveActionId = 'save';
 const shareActionId = 'share';
 const subtitleActionId = 'subtitles';
 const downloadActionId = 'download';
-const responsiveActionOrder = [shareActionId];
-const overflowActionOrder = [shareActionId, subtitleActionId, downloadActionId];
+const responsiveActionOrder = [saveActionId, shareActionId];
+const overflowActionOrder = [saveActionId, shareActionId, subtitleActionId, downloadActionId];
 
 const displayUploader = computed(() => props.videoInfo.uploader || 'IPFS Node');
 const displayChannelText = computed(() => {
@@ -119,6 +125,9 @@ const displayUploadDateTooltip = computed(() => formatUploadDateTooltip(props.vi
 const displayRelativeUploadTime = computed(() => {
   return formatRelativeUploadTime(props.videoInfo.uploadDate) || formatUploadDate(props.videoInfo.uploadDate);
 });
+const saveButtonLabel = computed(() => (props.isSaved ? 'Saved' : 'Save'));
+const saveButtonTitle = computed(() => (props.isSaved ? 'Remove from saved' : 'Save video'));
+const showSaveButton = computed(() => !hiddenActionIds.value.includes(saveActionId));
 const showShareButton = computed(() => !hiddenActionIds.value.includes(shareActionId));
 const downloadUrl = computed(() => buildSidecarAssetUrl(props.ipfsBaseUrl, 'index.m3u8'));
 const shareTimeLabel = computed(() => formatShareStartTime(sharePlaybackTime.value));
@@ -132,7 +141,7 @@ const overflowMenuItems = computed(() => {
     )
     .map((actionId) => ({
       id: actionId,
-      label: actionId === shareActionId ? '分享' : actionId === subtitleActionId ? '字幕' : '下載',
+      label: resolveOverflowActionLabel(actionId),
       disabled: actionId === downloadActionId && !downloadUrl.value,
     }));
 });
@@ -194,7 +203,7 @@ watch(
   { immediate: true }
 );
 
-watch([displayUploader, displayChannelText], () => {
+watch([displayUploader, displayChannelText, () => props.isSaved], () => {
   scheduleActionLayoutSync();
 });
 
@@ -259,6 +268,10 @@ function areActionIdsEqual(currentIds, nextIds) {
   return currentIds.every((id, index) => id === nextIds[index]);
 }
 
+function getResponsiveActionWidth(actionId, widthsByActionId) {
+  return widthsByActionId[actionId] || 0;
+}
+
 function resolveLayout() {
   const infoRowWidth = getElementWidth(infoRowRef.value);
   const creatorWidth = getElementWidth(creatorInfoRef.value);
@@ -269,9 +282,14 @@ function resolveLayout() {
   const creatorGap = getFlexGap(creatorInfoRef.value);
   const actionGroupWidth = getElementWidth(actionGroupRef.value);
   const moreActionsWidth = getElementWidth(moreMenuRef.value);
+  const saveWidth = getElementWidth(saveMeasureRef.value);
   const shareWidth = getElementWidth(shareMeasureRef.value);
   const infoGap = getFlexGap(infoRowRef.value);
   const actionsGap = getFlexGap(actionsRef.value);
+  const actionWidthsById = {
+    [saveActionId]: saveWidth,
+    [shareActionId]: shareWidth,
+  };
 
   if (!infoRowWidth || !creatorWidth || !actionGroupWidth || !moreActionsWidth) {
     return {
@@ -296,7 +314,7 @@ function resolveLayout() {
   const nextHiddenActionIds = [];
 
   for (const actionId of responsiveActionOrder) {
-    const actionWidth = actionId === shareActionId ? shareWidth : 0;
+    const actionWidth = getResponsiveActionWidth(actionId, actionWidthsById);
     const nextVisibleWidths = [...visibleActionWidths, actionWidth, moreActionsWidth];
 
     if (sumWidthsWithGap(nextVisibleWidths, actionsGap) <= availableActionsWidth + 1) {
@@ -310,7 +328,7 @@ function resolveLayout() {
   let totalVisibleWidth = actionGroupWidth;
   for (const actionId of responsiveActionOrder) {
     if (!nextHiddenActionIds.includes(actionId)) {
-      totalVisibleWidth += actionsGap + (actionId === shareActionId ? shareWidth : 0);
+      totalVisibleWidth += actionsGap + getResponsiveActionWidth(actionId, actionWidthsById);
     }
   }
   // The 'more' menu is always present because 'download' is always in the overflow menu
@@ -409,8 +427,29 @@ function downloadCurrentVideo() {
   document.body.removeChild(link);
 }
 
+function resolveOverflowActionLabel(actionId) {
+  if (actionId === saveActionId) {
+    return props.isSaved ? 'Remove' : saveButtonLabel.value;
+  }
+
+  if (actionId === shareActionId) {
+    return '分享';
+  }
+
+  if (actionId === subtitleActionId) {
+    return '字幕';
+  }
+
+  return '下載';
+}
+
 function handleOverflowAction(actionId) {
   closeMoreMenu();
+
+  if (actionId === saveActionId) {
+    handleSaveCurrentVideo();
+    return;
+  }
 
   if (actionId === shareActionId) {
     openShareDialog();
@@ -462,6 +501,14 @@ function openSubtitleDialog() {
   closeMoreMenu();
   closeShareDialog();
   isSubtitleDialogOpen.value = true;
+}
+
+function handleSaveCurrentVideo() {
+  if (!props.cid) {
+    return;
+  }
+
+  emit('save-current-video');
 }
 
 function handleSubtitleImport(importedTrack) {
@@ -762,10 +809,29 @@ onBeforeUnmount(() => {
           <button type="button" class="dislike-btn" title="Dislike" data-testid="video-info-dislike-button"><svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z"/></svg></button>
         </div>
 
+        <div ref="saveMeasureRef" class="glass-btn action-btn action-measure" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"/></svg>
+          <span class="btn-text">{{ saveButtonLabel }}</span>
+        </div>
+
         <div ref="shareMeasureRef" class="glass-btn action-btn action-measure" aria-hidden="true">
           <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/></svg>
           <span class="btn-text">Share</span>
         </div>
+
+        <button
+          v-if="showSaveButton"
+          type="button"
+          class="glass-btn action-btn"
+          :class="{ 'is-active': props.isSaved }"
+          data-action-item
+          data-testid="video-info-save-button"
+          @click="handleSaveCurrentVideo"
+          :title="saveButtonTitle"
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"/></svg>
+          <span class="btn-text">{{ saveButtonLabel }}</span>
+        </button>
 
         <button
           v-if="showShareButton"
@@ -802,15 +868,16 @@ onBeforeUnmount(() => {
               type="button"
               class="action-menu-item"
               role="menuitem"
-              :disabled="item.disabled"
-              :data-testid="`video-info-overflow-item-${item.id}`"
-              @click="handleOverflowAction(item.id)"
-            >
-              <svg v-if="item.id === shareActionId" class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/></svg>
-              <svg v-else-if="item.id === subtitleActionId" class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M4 5h16v10H7.17L4 18.17V5zm2 2v6.34L6.34 13H18V7H6zm2 1h8v2H8V8zm0 3h5v2H8v-2z"/></svg>
-              <svg v-else class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M5 20h14v-2H5v2zm7-18l-5.5 5.5 1.41 1.41L11 6.83V16h2V6.83l3.09 3.08 1.41-1.41L12 2z"/></svg>
-              <span class="menu-item-label">{{ item.label }}</span>
-            </button>
+            :disabled="item.disabled"
+            :data-testid="`video-info-overflow-item-${item.id}`"
+            @click="handleOverflowAction(item.id)"
+          >
+            <svg v-if="item.id === saveActionId" class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"/></svg>
+            <svg v-else-if="item.id === shareActionId" class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/></svg>
+            <svg v-else-if="item.id === subtitleActionId" class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M4 5h16v10H7.17L4 18.17V5zm2 2v6.34L6.34 13H18V7H6zm2 1h8v2H8V8zm0 3h5v2H8v-2z"/></svg>
+            <svg v-else class="menu-item-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M5 20h14v-2H5v2zm7-18l-5.5 5.5 1.41 1.41L11 6.83V16h2V6.83l3.09 3.08 1.41-1.41L12 2z"/></svg>
+            <span class="menu-item-label">{{ item.label }}</span>
+          </button>
           </div>
         </div>
       </div>
@@ -1143,6 +1210,11 @@ onBeforeUnmount(() => {
 .action-btn,
 .overflow-trigger {
   white-space: nowrap;
+}
+
+.action-btn.is-active {
+  border-color: rgba(255, 213, 89, 0.32);
+  color: #ffe082;
 }
 
 .action-measure {

--- a/src/components/WatchPage.vue
+++ b/src/components/WatchPage.vue
@@ -60,6 +60,10 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  isSaved: {
+    type: Boolean,
+    default: false,
+  },
   videoInfo: {
     type: Object,
     default: () => createDefaultVideoInfo(),
@@ -71,6 +75,7 @@ const emit = defineEmits([
   'gateway-fallback-request',
   'levels-loaded',
   'playback-snapshot',
+  'save-current-video',
   'subtitle-import',
   'subtitle-remove',
   'subtitle-selection-change',
@@ -90,6 +95,10 @@ function handleLevelsLoaded(levels) {
 
 function handlePlaybackSnapshot(snapshot) {
   emit('playback-snapshot', snapshot);
+}
+
+function handleSaveCurrentVideo() {
+  emit('save-current-video');
 }
 
 function handleSubtitleImport(importedTrack) {
@@ -131,12 +140,14 @@ function handleSubtitleSelectionChange(nextSelection) {
       :cid="cid"
       :avatar-url="avatarUrl"
       :ipfs-base-url="ipfsBaseUrl"
+      :is-saved="isSaved"
       :subtitles="subtitles"
       :subtitle-selection="subtitleSelection"
       :remote-subtitle-status="remoteSubtitleStatus"
       :video-info="videoInfo"
       :remote-subtitles="remoteSubtitles"
       :imported-subtitles="importedSubtitles"
+      @save-current-video="handleSaveCurrentVideo"
       @subtitle-import="handleSubtitleImport"
       @subtitle-remove="handleSubtitleRemove"
       @subtitle-selection-change="handleSubtitleSelectionChange"

--- a/src/components/video_layout.spec.js
+++ b/src/components/video_layout.spec.js
@@ -12,17 +12,21 @@ function getFirstStyleContent(descriptor) {
 }
 
 describe('App layout contract', () => {
-  it('renders watch with a conditional series playlist side panel and no longer uses the old status message slot', () => {
+  it('renders saved and history collection views alongside watch with a conditional series playlist side panel', () => {
     const descriptor = readDescriptor(new URL('../App.vue', import.meta.url));
     const template = descriptor.template?.content || '';
     const script = descriptor.scriptSetup?.content || '';
     const appStyle = readFileSync(new URL('../App.css', import.meta.url), 'utf8');
 
+    const historyPageIndex = template.indexOf('<HistoryPage');
+    const savedPageIndex = template.indexOf('<SavedVideosPage');
     const watchPageIndex = template.indexOf('<WatchPage');
     const seriesPlaylistIndex = template.indexOf('<SeriesPlaylistPage');
     const recommendationsPageIndex = template.indexOf('<RecommendationsPage v-else />');
 
     expect(template).toContain('<main class="main-content" data-testid="main-content">');
+    expect(historyPageIndex).toBeGreaterThan(-1);
+    expect(savedPageIndex).toBeGreaterThan(historyPageIndex);
     expect(watchPageIndex).toBeGreaterThan(-1);
     expect(seriesPlaylistIndex).toBeGreaterThan(watchPageIndex);
     expect(recommendationsPageIndex).toBeGreaterThan(seriesPlaylistIndex);
@@ -31,12 +35,16 @@ describe('App layout contract', () => {
     expect(template).not.toContain('data-testid="primary-column"');
     expect(template).not.toContain('data-testid="secondary-column"');
     expect(template).not.toContain('data-testid="page-shell"');
+    expect(template).toContain("v-else-if=\"activeView === 'saved'\"");
     expect(template).toContain('@gateway-fallback-request="onGatewayFallbackRequest"');
     expect(template).toContain('v-if="shouldShowSeriesPlaylist"');
     expect(template).toContain('@select="selectSeriesEpisode"');
     expect(script).toContain('defaultPublicGateway');
+    expect(script).toContain("import SavedVideosPage from './components/SavedVideosPage.vue';");
     expect(script).toContain("import SeriesPlaylistPage from './components/SeriesPlaylistPage.vue';");
+    expect(script).toContain("const isCurrentVideoSaved = computed(() => Boolean(findSavedEntry(currentCid.value)));");
     expect(script).toContain("const shouldShowSeriesPlaylist = computed(() => ['series', 'series-error'].includes(currentSourceMode.value));");
+    expect(script).toContain('function onSaveCurrentVideo() {');
     expect(script).toContain('function selectSeriesEpisode(episode) {');
     expect(script).toContain('function onGatewayFallbackRequest(payload = {}) {');
     expect(appStyle).toContain('.main-content');
@@ -133,11 +141,14 @@ describe('WatchPage layout contract', () => {
     expect(template).toContain('@playback-snapshot="handlePlaybackSnapshot"');
     expect(template).toContain(':remote-subtitles="remoteSubtitles"');
     expect(template).toContain(':imported-subtitles="importedSubtitles"');
+    expect(template).toContain(':is-saved="isSaved"');
+    expect(template).toContain('@save-current-video="handleSaveCurrentVideo"');
     expect(template).toContain('@subtitle-import="handleSubtitleImport"');
     expect(template).toContain('@subtitle-remove="handleSubtitleRemove"');
     expect(script).toContain("function handleGatewayFallbackRequest(payload) {");
     expect(template).toContain('@subtitle-selection-change="handleSubtitleSelectionChange"');
     expect(script).toContain("function handlePlaybackSnapshot(snapshot) {");
+    expect(script).toContain("function handleSaveCurrentVideo() {");
     expect(script).toContain("function handleSubtitleImport(importedTrack) {");
     expect(script).toContain("function handleSubtitleRemove(trackId) {");
     expect(script).toContain("function handleSubtitleSelectionChange(nextSelection) {");
@@ -434,6 +445,37 @@ describe('HistoryPage status contract', () => {
   });
 });
 
+describe('SavedVideosPage layout contract', () => {
+  it('renders a manual saved list with local-only messaging and remove actions', () => {
+    const descriptor = readDescriptor(new URL('./SavedVideosPage.vue', import.meta.url));
+    const template = descriptor.template?.content || '';
+    const script = descriptor.scriptSetup?.content || '';
+    const style = getFirstStyleContent(descriptor);
+
+    expect(template).toContain('<section class="saved-page" data-testid="saved-page">');
+    expect(template).toContain('data-testid="saved-empty"');
+    expect(template).toContain('data-testid="saved-list"');
+    expect(template).toContain(':data-testid="`saved-item-${item.cid}`"');
+    expect(template).toContain('class="saved-status-badge"');
+    expect(template).toContain('class="saved-open-label"');
+    expect(template).toContain('你手動儲存的影片會保留在本機列表');
+    expect(template).toContain('@click="handleSelect(item)"');
+    expect(template).toContain('@click="handleRemove(item.cid)"');
+
+    expect(script).toContain("const emit = defineEmits(['select', 'remove']);");
+    expect(script).toContain('savedAtLabel: formatSavedAt(item.savedAt)');
+    expect(script).toContain('function formatSavedAt(value) {');
+    expect(script).toContain("return '剛剛儲存';");
+
+    expect(style).toContain('.saved-page');
+    expect(style).toContain('.saved-list');
+    expect(style).toContain('.saved-item');
+    expect(style).toContain('.saved-thumb');
+    expect(style).toContain('.saved-status-badge');
+    expect(style).toContain('.saved-remove');
+  });
+});
+
 describe('RecommendationsPage layout contract', () => {
   it('keeps the recommendations list inside its own page container', () => {
     const descriptor = readDescriptor(new URL('./RecommendationsPage.vue', import.meta.url));
@@ -516,7 +558,7 @@ describe('VideoInfo layout contract', () => {
     expect(script).toContain("{ label: 'Channel ID', value: props.videoInfo.channelId }");
   });
 
-  it('moves download into an overflow menu and lets share collapse before like or dislike', () => {
+  it('keeps save and share in the responsive action row while leaving download in the overflow menu', () => {
     const descriptor = readDescriptor(new URL('./VideoInfo.vue', import.meta.url));
     const template = descriptor.template?.content || '';
     const script = descriptor.scriptSetup?.content || '';
@@ -525,14 +567,25 @@ describe('VideoInfo layout contract', () => {
     expect(template).toContain('<div ref="moreMenuRef" class="more-actions" data-action-item data-testid="video-info-more-actions">');
     expect(template).toContain('class="actions-menu glass-panel" role="menu"');
     expect(template).toContain('v-for="item in overflowMenuItems"');
+    expect(template).toContain('data-testid="video-info-save-button"');
+    expect(template).toContain(':data-testid="`video-info-overflow-item-${item.id}`"');
+    expect(template).toContain('ref="saveMeasureRef"');
     expect(template).toContain("v-if=\"showShareButton\"");
+    expect(template).toContain("v-if=\"showSaveButton\"");
     expect(template).toContain('class="action-group glass-btn" data-action-item');
+    expect(template).toContain('item.id === saveActionId');
     expect(template).toContain('item.id === subtitleActionId');
     expect(template).toContain('<SubtitleDialog');
 
-    expect(script).toContain("const responsiveActionOrder = [shareActionId];");
-    expect(script).toContain("const overflowActionOrder = [shareActionId, subtitleActionId, downloadActionId];");
+    expect(script).toContain("const saveActionId = 'save';");
+    expect(script).toContain("const responsiveActionOrder = [saveActionId, shareActionId];");
+    expect(script).toContain("const overflowActionOrder = [saveActionId, shareActionId, subtitleActionId, downloadActionId];");
+    expect(script).toContain("const saveButtonLabel = computed(() => (props.isSaved ? 'Saved' : 'Save'));");
+    expect(script).toContain("const showSaveButton = computed(() => !hiddenActionIds.value.includes(saveActionId));");
     expect(script).toContain("const showShareButton = computed(() => !hiddenActionIds.value.includes(shareActionId));");
+    expect(script).toContain('function getResponsiveActionWidth(actionId, widthsByActionId) {');
+    expect(script).toContain('function resolveOverflowActionLabel(actionId) {');
+    expect(script).toContain("emit('save-current-video');");
     expect(script).toContain('function resolveLayout()');
     expect(script).toContain('const nextCreatorTextHidden = fullCreatorWidth > infoRowWidth + 1;');
     expect(script).toContain('const nextCreatorWidth = nextCreatorTextHidden ? compactCreatorWidth : fullCreatorWidth;');
@@ -604,12 +657,11 @@ describe('VideoInfo layout contract', () => {
     expect(style).toContain('.creator-info-compact .subscribe-btn');
   });
 
-  it('places dynamically collapsed items at the top of the overflow menu (e.g. share before download)', () => {
+  it('places dynamically collapsed items at the top of the overflow menu (save, then share, before subtitle or download)', () => {
     const descriptor = readDescriptor(new URL('./VideoInfo.vue', import.meta.url));
     const script = descriptor.scriptSetup?.content || '';
 
-    // Verify the overflow action order array places share before subtitles and download
-    expect(script).toContain("const overflowActionOrder = [shareActionId, subtitleActionId, downloadActionId];");
+    expect(script).toContain("const overflowActionOrder = [saveActionId, shareActionId, subtitleActionId, downloadActionId];");
   });
 
   it('collapses the description by default and exposes explicit expand and collapse controls', () => {

--- a/src/i18n/messages/en.js
+++ b/src/i18n/messages/en.js
@@ -192,7 +192,7 @@ export default Object.freeze({
     menu: {
       home: 'Home',
       explore: 'Explore',
-      library: 'Library',
+      library: 'Saved',
       history: 'History',
     },
     build: {

--- a/src/i18n/messages/ja.js
+++ b/src/i18n/messages/ja.js
@@ -192,7 +192,7 @@ export default Object.freeze({
     menu: {
       home: 'ホーム',
       explore: '探索',
-      library: 'ライブラリ',
+      library: '保存済み',
       history: '履歴',
     },
     build: {

--- a/src/i18n/messages/zh-TW.js
+++ b/src/i18n/messages/zh-TW.js
@@ -192,7 +192,7 @@ export default Object.freeze({
     menu: {
       home: '首頁',
       explore: '探索',
-      library: '媒體庫',
+      library: '已儲存',
       history: '觀看紀錄',
     },
     build: {

--- a/src/utils/savedVideos.js
+++ b/src/utils/savedVideos.js
@@ -1,0 +1,140 @@
+export const savedVideosStorageKey = 'ipfs-hls-saved-videos';
+export const defaultSavedVideosLimit = 100;
+
+function resolveStorage(target) {
+  if (target && typeof target.getItem === 'function') {
+    return target;
+  }
+
+  if (target?.localStorage && typeof target.localStorage.getItem === 'function') {
+    return target.localStorage;
+  }
+
+  if (typeof window !== 'undefined' && window?.localStorage && typeof window.localStorage.getItem === 'function') {
+    return window.localStorage;
+  }
+
+  return null;
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeNonNegativeInteger(value) {
+  const numeric = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
+}
+
+function normalizeTimestamp(value) {
+  const numeric = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : Date.now();
+}
+
+function sortSavedVideoItems(items) {
+  return [...items].sort((left, right) => (right.savedAt ?? 0) - (left.savedAt ?? 0));
+}
+
+function writeStoredSavedVideos(items, target) {
+  const storage = resolveStorage(target);
+  if (!storage) return;
+
+  try {
+    if (!Array.isArray(items) || items.length === 0) {
+      if (typeof storage.removeItem === 'function') {
+        storage.removeItem(savedVideosStorageKey);
+      }
+      return;
+    }
+
+    storage.setItem(savedVideosStorageKey, JSON.stringify(items));
+  } catch (_) {
+    // ignore storage errors
+  }
+}
+
+export function normalizeSavedVideoItem(payload = {}) {
+  return {
+    cid: normalizeString(payload.cid),
+    seriesCid: normalizeString(payload.seriesCid),
+    episodeId: normalizeString(payload.episodeId),
+    episodePath: normalizeString(payload.episodePath),
+    title: normalizeString(payload.title),
+    uploader: normalizeString(payload.uploader),
+    posterUrl: normalizeString(payload.posterUrl),
+    gateway: normalizeString(payload.gateway),
+    durationString: normalizeString(payload.durationString),
+    durationSeconds: normalizeNonNegativeInteger(payload.durationSeconds),
+    savedAt: normalizeTimestamp(payload.savedAt),
+  };
+}
+
+export function readStoredSavedVideos(target) {
+  const storage = resolveStorage(target);
+  if (!storage) return [];
+
+  try {
+    const rawValue = storage.getItem(savedVideosStorageKey);
+    if (!rawValue) return [];
+
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) return [];
+
+    return sortSavedVideoItems(
+      parsed
+        .map((item) => normalizeSavedVideoItem(item))
+        .filter((item) => item.cid)
+    );
+  } catch (_) {
+    return [];
+  }
+}
+
+function mergeSavedVideoItem(existing, next) {
+  return {
+    cid: next.cid || existing.cid,
+    seriesCid: next.seriesCid || existing.seriesCid,
+    episodeId: next.episodeId || existing.episodeId,
+    episodePath: next.episodePath || existing.episodePath,
+    title: next.title || existing.title,
+    uploader: next.uploader || existing.uploader,
+    posterUrl: next.posterUrl || existing.posterUrl,
+    gateway: next.gateway || existing.gateway,
+    durationString: next.durationString || existing.durationString,
+    durationSeconds: next.durationSeconds > 0 ? next.durationSeconds : existing.durationSeconds,
+    savedAt: next.savedAt || existing.savedAt || Date.now(),
+  };
+}
+
+export function upsertSavedVideoEntry(entry, target, options = {}) {
+  const limit = Number.isInteger(options.limit) && options.limit > 0 ? options.limit : defaultSavedVideosLimit;
+  const normalizedEntry = normalizeSavedVideoItem(entry);
+
+  if (!normalizedEntry.cid) {
+    return readStoredSavedVideos(target);
+  }
+
+  const currentItems = readStoredSavedVideos(target);
+  const existingIndex = currentItems.findIndex((item) => item.cid === normalizedEntry.cid);
+  const mergedEntry =
+    existingIndex >= 0 ? mergeSavedVideoItem(currentItems[existingIndex], normalizedEntry) : normalizedEntry;
+
+  const nextItems = sortSavedVideoItems([
+    mergedEntry,
+    ...currentItems.filter((item) => item.cid !== normalizedEntry.cid),
+  ]).slice(0, limit);
+
+  writeStoredSavedVideos(nextItems, target);
+  return nextItems;
+}
+
+export function removeSavedVideoEntry(cid, target) {
+  const normalizedCid = normalizeString(cid);
+  if (!normalizedCid) {
+    return readStoredSavedVideos(target);
+  }
+
+  const nextItems = readStoredSavedVideos(target).filter((item) => item.cid !== normalizedCid);
+  writeStoredSavedVideos(nextItems, target);
+  return nextItems;
+}

--- a/src/utils/savedVideos.spec.js
+++ b/src/utils/savedVideos.spec.js
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  defaultSavedVideosLimit,
+  readStoredSavedVideos,
+  removeSavedVideoEntry,
+  savedVideosStorageKey,
+  upsertSavedVideoEntry,
+} from './savedVideos';
+
+function createStorage() {
+  const data = new Map();
+
+  return {
+    getItem(key) {
+      return data.has(key) ? data.get(key) : null;
+    },
+    setItem(key, value) {
+      data.set(key, String(value));
+    },
+    removeItem(key) {
+      data.delete(key);
+    },
+  };
+}
+
+describe('saved videos storage', () => {
+  it('returns an empty list when storage is unavailable', () => {
+    expect(readStoredSavedVideos(null)).toEqual([]);
+  });
+
+  it('stores and sorts saved entries by most recent save time', () => {
+    const storage = createStorage();
+
+    upsertSavedVideoEntry(
+      {
+        cid: 'bafy-old',
+        title: 'Old title',
+        savedAt: 100,
+      },
+      storage
+    );
+    const nextItems = upsertSavedVideoEntry(
+      {
+        cid: 'bafy-new',
+        title: 'New title',
+        savedAt: 200,
+      },
+      storage
+    );
+
+    expect(nextItems.map((item) => item.cid)).toEqual(['bafy-new', 'bafy-old']);
+    expect(readStoredSavedVideos(storage).map((item) => item.cid)).toEqual(['bafy-new', 'bafy-old']);
+  });
+
+  it('merges non-empty fields with existing entries instead of blanking them out', () => {
+    const storage = createStorage();
+
+    upsertSavedVideoEntry(
+      {
+        cid: 'bafy-saved',
+        title: 'Saved title',
+        uploader: 'Uploader',
+        durationString: '10:16',
+        savedAt: 100,
+      },
+      storage
+    );
+
+    const nextItems = upsertSavedVideoEntry(
+      {
+        cid: 'bafy-saved',
+        title: '',
+        uploader: '',
+        savedAt: 150,
+      },
+      storage
+    );
+
+    expect(nextItems).toEqual([
+      {
+        cid: 'bafy-saved',
+        seriesCid: '',
+        episodeId: '',
+        episodePath: '',
+        title: 'Saved title',
+        uploader: 'Uploader',
+        posterUrl: '',
+        gateway: '',
+        durationString: '10:16',
+        durationSeconds: 0,
+        savedAt: 150,
+      },
+    ]);
+  });
+
+  it('deduplicates by cid and moves a re-saved item to the top', () => {
+    const storage = createStorage();
+
+    upsertSavedVideoEntry({ cid: 'bafy-a', title: 'A', savedAt: 100 }, storage);
+    upsertSavedVideoEntry({ cid: 'bafy-b', title: 'B', savedAt: 200 }, storage);
+
+    const nextItems = upsertSavedVideoEntry({ cid: 'bafy-a', title: 'A', savedAt: 300 }, storage);
+
+    expect(nextItems.map((item) => item.cid)).toEqual(['bafy-a', 'bafy-b']);
+    expect(nextItems).toHaveLength(2);
+  });
+
+  it('removes entries by cid', () => {
+    const storage = createStorage();
+
+    upsertSavedVideoEntry({ cid: 'bafy-a', title: 'A', savedAt: 100 }, storage);
+    upsertSavedVideoEntry({ cid: 'bafy-b', title: 'B', savedAt: 200 }, storage);
+
+    expect(removeSavedVideoEntry('bafy-a', storage).map((item) => item.cid)).toEqual(['bafy-b']);
+    expect(readStoredSavedVideos(storage).map((item) => item.cid)).toEqual(['bafy-b']);
+  });
+
+  it('caps stored items to the configured limit', () => {
+    const storage = createStorage();
+
+    for (let index = 0; index < defaultSavedVideosLimit + 5; index += 1) {
+      upsertSavedVideoEntry(
+        {
+          cid: `bafy-${index}`,
+          title: `Video ${index}`,
+          savedAt: index + 1,
+        },
+        storage
+      );
+    }
+
+    const items = readStoredSavedVideos(storage);
+    expect(items).toHaveLength(defaultSavedVideosLimit);
+    expect(items[0].cid).toBe(`bafy-${defaultSavedVideosLimit + 4}`);
+  });
+
+  it('returns an empty list when stored JSON is invalid', () => {
+    const storage = createStorage();
+    storage.setItem(savedVideosStorageKey, '{broken');
+
+    expect(readStoredSavedVideos(storage)).toEqual([]);
+  });
+
+  it('normalizes missing timestamps using the current time', () => {
+    const storage = createStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-21T10:00:00Z'));
+
+    const items = upsertSavedVideoEntry(
+      {
+        cid: 'bafy-now',
+        title: 'Uses now',
+      },
+      storage
+    );
+
+    expect(items[0].savedAt).toBe(Date.parse('2026-03-21T10:00:00Z'));
+    vi.useRealTimers();
+  });
+
+  it('retains series episode context when present', () => {
+    const storage = createStorage();
+
+    const items = upsertSavedVideoEntry(
+      {
+        cid: 'bafy-series/ep02',
+        seriesCid: 'bafy-series',
+        episodeId: 'ep02',
+        episodePath: 'ep02',
+        title: 'Episode 2',
+        savedAt: 100,
+      },
+      storage
+    );
+
+    expect(items[0]).toEqual({
+      cid: 'bafy-series/ep02',
+      seriesCid: 'bafy-series',
+      episodeId: 'ep02',
+      episodePath: 'ep02',
+      title: 'Episode 2',
+      uploader: '',
+      posterUrl: '',
+      gateway: '',
+      durationString: '',
+      durationSeconds: 0,
+      savedAt: 100,
+    });
+  });
+});


### PR DESCRIPTION
## Why
- 觀看歷史會隨播放自動變動，缺少一個由使用者主動控制的本機收藏列表。
- issue #43 需要支援手動儲存目前影片，並且讓系列播放能記住當前集數。

## What
- 新增 `savedVideos` 本機儲存資料層與 `Saved` 側欄頁面。
- 在觀看頁加入 `Save / Saved` 切換按鈕，再次點擊會直接移除。
- 系列播放會儲存當前集數，不會把自動 gateway fallback 寫回使用者偏好的 gateway。
- 補齊 layout contract、saved list、series playlist 與 responsive actions 測試。

## Validation
- `npm test`
- `npm run build`
- `npm exec playwright test e2e/series_playlist.e2e.js`
- `npm exec playwright test e2e/rwd.e2e.js --grep "Responsive Video Actions"`

## Notes
- 本 PR 只處理單一本機 Saved list，不包含匯入、匯出、多播放列表或同步。

Closes #43
