### PR TITLE
feature(gateway): 支援網關設定恢復預設值

### DIFF
--- a/e2e/rwd.e2e.js
+++ b/e2e/rwd.e2e.js
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 const gatewayStorageKey = 'ipfs-hls-selected-gateway';
+const customGatewayStorageKey = 'ipfs-hls-custom-gateway';
+const localGatewayStorageKey = 'ipfs-hls-local-gateway';
 const localGatewayBase = 'http://127.0.0.1:8080/ipfs/';
 const testGatewayBase = 'https://dweb.link/ipfs/';
 const mirroredGatewayBases = [localGatewayBase, 'https://dweb.link/ipfs/', 'https://ipfs.io/ipfs/'];
@@ -128,6 +130,45 @@ async function openApp(page, url = './', options = {}) {
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   await expect(page.getByTestId('app-header')).toBeVisible();
   await expect(page.getByTestId('main-content')).toBeVisible();
+}
+
+async function seedGatewaySettingsStorage(
+  page,
+  {
+    selectedGateway = testGatewayBase,
+    customGateway = '',
+    localGateway = null,
+  } = {}
+) {
+  await page.addInitScript(
+    ({ gatewayKey, customKey, localKey, nextSelectedGateway, nextCustomGateway, nextLocalGateway }) => {
+      if (nextSelectedGateway) {
+        window.localStorage.setItem(gatewayKey, nextSelectedGateway);
+      } else {
+        window.localStorage.removeItem(gatewayKey);
+      }
+
+      if (nextCustomGateway) {
+        window.localStorage.setItem(customKey, nextCustomGateway);
+      } else {
+        window.localStorage.removeItem(customKey);
+      }
+
+      if (nextLocalGateway) {
+        window.localStorage.setItem(localKey, JSON.stringify(nextLocalGateway));
+      } else {
+        window.localStorage.removeItem(localKey);
+      }
+    },
+    {
+      gatewayKey: gatewayStorageKey,
+      customKey: customGatewayStorageKey,
+      localKey: localGatewayStorageKey,
+      nextSelectedGateway: selectedGateway,
+      nextCustomGateway: customGateway,
+      nextLocalGateway: localGateway,
+    }
+  );
 }
 
 async function getBox(locator) {
@@ -963,7 +1004,7 @@ test.describe('Responsive Gateway Dialog', () => {
     await customOption.click();
     await expect(page.getByTestId('gateway-custom-config')).toBeVisible();
     await expect(page.getByTestId('gateway-local-config')).toHaveCount(0);
-    await expect(page.getByTestId('gateway-transition-note')).toBeVisible();
+    await expect(page.getByTestId('gateway-transition-note')).toHaveCount(0);
     await expect(localOption).toHaveClass(/current/);
     await expect(localOption).not.toHaveClass(/selected/);
     await expect(localOption).toContainText('Current');
@@ -986,5 +1027,117 @@ test.describe('Responsive Gateway Dialog', () => {
     await expect(localOption).toHaveClass(/current/);
     await expect(localOption).toHaveClass(/selected/);
     await expect(localOption).toContainText('Current Selection');
+  });
+});
+
+test.describe('Gateway draft restore defaults', () => {
+  const customGatewayUrl = 'https://friend.example/ipfs/';
+  const storedLocalGateway = {
+    host: '192.168.1.70',
+    port: '9999',
+  };
+
+  test('applies restored custom and local defaults after Apply even when a public gateway stays selected', async ({ page }) => {
+    await seedGatewaySettingsStorage(page, {
+      selectedGateway: testGatewayBase,
+      customGateway: customGatewayUrl,
+      localGateway: storedLocalGateway,
+    });
+    await openApp(page);
+
+    await openGatewayDialog(page);
+
+    await page.getByTestId('gateway-option-custom').click();
+    const customInput = page.locator('#customGateway');
+    await expect(customInput).toHaveValue(customGatewayUrl);
+    await page.getByTestId('gateway-custom-reset-button').click();
+    await expect(customInput).toHaveValue('');
+    await expect(page.getByTestId('gateway-transition-note')).toContainText('Restore Custom Gateway defaults');
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), customGatewayStorageKey)).toBe(customGatewayUrl);
+
+    await page.getByTestId('gateway-option-local').click();
+    const localHost = page.locator('#localHost');
+    const localPort = page.locator('#localPort');
+    await expect(localHost).toHaveValue(storedLocalGateway.host);
+    await expect(localPort).toHaveValue(storedLocalGateway.port);
+    await page.getByTestId('gateway-local-reset-button').click();
+    await expect(localHost).toHaveValue('127.0.0.1');
+    await expect(localPort).toHaveValue('8080');
+    await expect(page.getByTestId('gateway-transition-note')).toContainText('Restore Local Node defaults');
+    expect(JSON.parse(await page.evaluate((key) => window.localStorage.getItem(key), localGatewayStorageKey))).toEqual(
+      storedLocalGateway
+    );
+
+    await page.getByTestId('gateway-option-dweb').click();
+    await page.getByRole('button', { name: 'Apply' }).click();
+    await expect(page.getByTestId('gateway-dialog')).toHaveCount(0);
+
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), gatewayStorageKey)).toBe(testGatewayBase);
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), customGatewayStorageKey)).toBeNull();
+    expect(JSON.parse(await page.evaluate((key) => window.localStorage.getItem(key), localGatewayStorageKey))).toEqual({
+      host: '127.0.0.1',
+      port: '8080',
+    });
+
+    await openGatewayDialog(page);
+    await page.getByTestId('gateway-option-custom').click();
+    await expect(page.locator('#customGateway')).toHaveValue('');
+    await page.getByTestId('gateway-option-local').click();
+    await expect(page.locator('#localHost')).toHaveValue('127.0.0.1');
+    await expect(page.locator('#localPort')).toHaveValue('8080');
+  });
+
+  test('keeps restored defaults as draft-only changes until Apply', async ({ page }) => {
+    await seedGatewaySettingsStorage(page, {
+      selectedGateway: testGatewayBase,
+      customGateway: customGatewayUrl,
+      localGateway: storedLocalGateway,
+    });
+    await openApp(page);
+
+    await openGatewayDialog(page);
+    await page.getByTestId('gateway-option-custom').click();
+    await page.getByTestId('gateway-custom-reset-button').click();
+    await page.getByTestId('gateway-option-local').click();
+    await page.getByTestId('gateway-local-reset-button').click();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), customGatewayStorageKey)).toBe(customGatewayUrl);
+    expect(JSON.parse(await page.evaluate((key) => window.localStorage.getItem(key), localGatewayStorageKey))).toEqual(
+      storedLocalGateway
+    );
+
+    await openGatewayDialog(page);
+    await page.getByTestId('gateway-option-custom').click();
+    await expect(page.locator('#customGateway')).toHaveValue(customGatewayUrl);
+    await page.getByTestId('gateway-option-local').click();
+    await expect(page.locator('#localHost')).toHaveValue(storedLocalGateway.host);
+    await expect(page.locator('#localPort')).toHaveValue(storedLocalGateway.port);
+  });
+
+  test('blocks Apply atomically when Custom Gateway is selected but has been reset to blank', async ({ page }) => {
+    await seedGatewaySettingsStorage(page, {
+      selectedGateway: customGatewayUrl,
+      customGateway: customGatewayUrl,
+      localGateway: storedLocalGateway,
+    });
+    await openApp(page);
+
+    await openGatewayDialog(page);
+    await page.getByTestId('gateway-option-local').click();
+    await page.getByTestId('gateway-local-reset-button').click();
+    await page.getByTestId('gateway-option-custom').click();
+    await page.getByTestId('gateway-custom-reset-button').click();
+    await page.getByRole('button', { name: 'Apply' }).click();
+
+    await expect(page.getByTestId('gateway-error')).toHaveText(
+      'Choose another gateway or enter a valid custom gateway before applying.'
+    );
+    await expect(page.getByTestId('gateway-dialog')).toBeVisible();
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), gatewayStorageKey)).toBe(customGatewayUrl);
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), customGatewayStorageKey)).toBe(customGatewayUrl);
+    expect(JSON.parse(await page.evaluate((key) => window.localStorage.getItem(key), localGatewayStorageKey))).toEqual(
+      storedLocalGateway
+    );
   });
 });

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,13 +4,19 @@ import InfoJsonDialog from './InfoJsonDialog.vue';
 import LocalEnvironmentPanel from './LocalEnvironmentPanel.vue';
 import { useI18n } from '../i18n';
 import {
+  defaultLocalGatewayHost,
+  defaultLocalGatewayPort,
   isDisabledGatewayInput,
   isPrivateHostname,
   normalizeGatewayUrl,
+  normalizeLocalGatewayHost,
+  normalizeLocalGatewayPort,
   persistCustomGateway,
+  persistLocalGatewayConfig,
   probeGatewayAvailability,
   publicGatewayOptions,
   readStoredCustomGateway,
+  readStoredLocalGatewayConfig,
 } from '../utils/gateway';
 import {
   createEnvironmentCheckStateFromPayload,
@@ -25,7 +31,6 @@ import { createDefaultVideoInfo } from '../utils/videoInfo';
 const LOCAL_GATEWAY_ID = 'local';
 const CUSTOM_GATEWAY_ID = 'custom';
 const isDevMode = import.meta.env.DEV;
-const localStorageKey = 'ipfs-hls-local-gateway';
 const localEnvironmentApiStorageKey = 'ipfs-hls-local-environment-api';
 const localGatewayOption = {
   id: LOCAL_GATEWAY_ID,
@@ -79,6 +84,9 @@ const isMobileLocaleListOpen = ref(false);
 const isInfoJsonDialogOpen = ref(false);
 const lastFocusedGatewayTrigger = ref(null);
 const pendingGatewayFocusTarget = ref(null);
+const storedLocalHost = ref(defaultLocalGatewayHost);
+const storedLocalPort = ref(defaultLocalGatewayPort);
+const storedCustomGateway = ref('');
 
 const localGatewayUrl = computed(() => `http://${localHost.value}:${localPort.value}/ipfs/`);
 const normalizedLocalEnvironmentHost = computed(() => normalizeLocalHost(localHost.value) || '127.0.0.1');
@@ -270,23 +278,56 @@ const selectedGatewayName = computed(() => {
   const selectedGateway = builtInGateways.find((gateway) => gateway.id === selectedGatewayId.value);
   return selectedGateway?.label || builtInGateways[0]?.label || 'Gateway';
 });
-const hasPendingGatewayChange = computed(() => {
+const isLocalGatewayDraftDefault = computed(
+  () =>
+    normalizeLocalGatewayHost(localHost.value) === defaultLocalGatewayHost &&
+    normalizeLocalGatewayPort(localPort.value) === defaultLocalGatewayPort
+);
+const hasPendingLocalGatewayReset = computed(
+  () =>
+    isDevMode &&
+    isLocalGatewayDraftDefault.value &&
+    (storedLocalHost.value !== defaultLocalGatewayHost || storedLocalPort.value !== defaultLocalGatewayPort)
+);
+const hasPendingCustomGatewayReset = computed(() => !customGatewayPreview.value && Boolean(storedCustomGateway.value));
+const hasPendingGatewaySelectionChange = computed(() => {
   const selected = selectedGatewayValue.value;
   const current = currentGatewayValue.value;
 
-  if (selected && selected !== current) return true;
+  if (!selected) return false;
+  if (selected !== current) return true;
 
   return selectedGatewayId.value !== currentGatewayId.value;
 });
+const hasPendingGatewayChange = computed(
+  () =>
+    hasPendingGatewaySelectionChange.value || hasPendingLocalGatewayReset.value || hasPendingCustomGatewayReset.value
+);
 const gatewayChangeSummary = computed(() => {
   if (!hasPendingGatewayChange.value) return '';
 
-  if (!currentGatewayValue.value) {
-    return `Use ${selectedGatewayName.value}`;
+  const messages = [];
+
+  if (hasPendingGatewaySelectionChange.value) {
+    if (!currentGatewayValue.value) {
+      messages.push(`Use ${selectedGatewayName.value}`);
+    } else {
+      messages.push(`Switch from ${currentGatewayName.value} to ${selectedGatewayName.value}`);
+    }
   }
 
-  return `Switch from ${currentGatewayName.value} to ${selectedGatewayName.value}`;
+  if (hasPendingLocalGatewayReset.value) {
+    messages.push('Restore Local Node defaults');
+  }
+
+  if (hasPendingCustomGatewayReset.value) {
+    messages.push('Restore Custom Gateway defaults');
+  }
+
+  return messages.join(' · ');
 });
+const canRestoreCustomGatewayDefaults = computed(() => Boolean(customGateway.value.trim()));
+const canRestoreLocalGatewayDefaults = computed(() => isDevMode && !isLocalGatewayDraftDefault.value);
 const currentGatewayKind = computed(() => {
   const current = currentGatewayValue.value;
   if (!current) return 'public';
@@ -554,11 +595,11 @@ function syncLocalFromGateway(urlStr) {
 }
 
 function normalizeLocalHost(value) {
-  return value.trim().replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:\d+$/, '');
+  return normalizeLocalGatewayHost(value);
 }
 
 function normalizeLocalPort(value) {
-  return normalizePort(value, '8080');
+  return normalizeLocalGatewayPort(value);
 }
 
 function normalizeEnvironmentApiPort(value) {
@@ -571,7 +612,6 @@ function normalizePort(value, fallback = '8080') {
     .replace(/[^0-9]/g, '');
   return digits || fallback;
 }
-
 function gatewayUrl(gateway) {
   return gateway.id === LOCAL_GATEWAY_ID ? localGatewayUrl.value : gateway.url;
 }
@@ -593,21 +633,63 @@ function openSettings() {
   closeMobileActionsMenu({ restoreFocus: false });
   closeInfoJsonDialog();
   if (isDevMode) {
-    restoreLocalGateway();
+    const storedLocalConfig = readStoredLocalGatewayConfig(window);
+    localHost.value = storedLocalConfig.host;
+    localPort.value = storedLocalConfig.port;
     syncLocalFromGateway(props.currentGateway);
   }
-  customGateway.value = readStoredCustomGateway(window) || customGateway.value;
+  customGateway.value = readStoredCustomGateway(window);
   if (isDisabledGatewayInput(customGateway.value)) {
     customGateway.value = '';
     persistCustomGateway('', window);
   }
   syncSelectionFromGateway(props.currentGateway);
+  captureStoredGatewayDrafts();
   gatewayError.value = '';
   settingsOpen.value = true;
 }
 
 function closeSettings() {
   settingsOpen.value = false;
+}
+
+function syncLocalGatewayDraftProbeState() {
+  if (!isDevMode) return;
+
+  const now = Date.now();
+  const cooldownUntil = readGatewayCooldown(localGatewayUrl.value);
+  gatewayProbeStates.value = {
+    ...gatewayProbeStates.value,
+    [LOCAL_GATEWAY_ID]:
+      currentCidValue.value && cooldownUntil > now ? createRateLimitedProbeState(cooldownUntil) : createIdleProbeState(),
+  };
+}
+
+function syncCustomGatewayDraftProbeState() {
+  const now = Date.now();
+  const cooldownUntil = readGatewayCooldown(customGatewayPreview.value);
+  gatewayProbeStates.value = {
+    ...gatewayProbeStates.value,
+    [CUSTOM_GATEWAY_ID]:
+      currentCidValue.value && cooldownUntil > now
+        ? createRateLimitedProbeState(cooldownUntil)
+        : createIdleProbeState(customGatewayPreview.value ? '等待檢查播放清單與媒體片段' : '輸入 HTTPS gateway 後可檢查'),
+  };
+}
+
+function restoreCustomGatewayDefaults() {
+  customGateway.value = '';
+  gatewayError.value = '';
+  syncCustomGatewayDraftProbeState();
+}
+
+function restoreLocalGatewayDefaults() {
+  if (!isDevMode) return;
+
+  localHost.value = defaultLocalGatewayHost;
+  localPort.value = defaultLocalGatewayPort;
+  gatewayError.value = '';
+  syncLocalGatewayDraftProbeState();
 }
 
 function openInfoJsonDialog() {
@@ -623,6 +705,48 @@ function closeInfoJsonDialog() {
 
 function applyGateway() {
   gatewayError.value = '';
+  const normalizedLocalHost = normalizeLocalGatewayHost(localHost.value);
+  const normalizedLocalPort = normalizeLocalGatewayPort(localPort.value);
+  const hasCustomDraftInput = customGateway.value.trim().length > 0;
+  const shouldPersistLocalReset = hasPendingLocalGatewayReset.value;
+  const shouldPersistCustomReset = hasPendingCustomGatewayReset.value;
+  const isSelectedCustomGateway = selectedGatewayId.value === CUSTOM_GATEWAY_ID;
+
+  if (isSelectedCustomGateway && isDisabledGatewayInput(customGateway.value)) {
+    gatewayError.value = 'Pinata gateway has been removed. Please choose another gateway.';
+    return;
+  }
+
+  const normalizedCustomGateway = hasCustomDraftInput ? normalizeGatewayUrl(customGateway.value) : '';
+  if (isSelectedCustomGateway && hasCustomDraftInput && !normalizedCustomGateway) {
+    gatewayError.value = 'Enter a valid public HTTPS gateway URL that ends with /ipfs/.';
+    return;
+  }
+
+  if (isSelectedCustomGateway && !normalizedCustomGateway) {
+    gatewayError.value = 'Choose another gateway or enter a valid custom gateway before applying.';
+    return;
+  }
+
+  if (isDevMode) {
+    localHost.value = normalizedLocalHost;
+    localPort.value = normalizedLocalPort;
+  }
+  customGateway.value = normalizedCustomGateway;
+
+  if (isDevMode && (selectedGatewayId.value === LOCAL_GATEWAY_ID || shouldPersistLocalReset)) {
+    persistLocalGatewayConfig(
+      {
+        host: normalizedLocalHost,
+        port: normalizedLocalPort,
+      },
+      window
+    );
+  }
+
+  if (selectedGatewayId.value === CUSTOM_GATEWAY_ID || shouldPersistCustomReset) {
+    persistCustomGateway(normalizedCustomGateway, window);
+  }
 
   let nextGateway = '';
 
@@ -631,28 +755,16 @@ function applyGateway() {
       selectedGatewayId.value = builtInGateways[0].id;
       nextGateway = gatewayUrl(builtInGateways[0]);
     } else {
-      localHost.value = normalizeLocalHost(localHost.value);
-      localPort.value = normalizeLocalPort(localPort.value);
       nextGateway = localGatewayUrl.value;
-      persistLocalGateway();
     }
   } else if (selectedGatewayId.value === CUSTOM_GATEWAY_ID) {
-    if (isDisabledGatewayInput(customGateway.value)) {
-      gatewayError.value = 'Pinata gateway has been removed. Please choose another gateway.';
-      return;
-    }
-    nextGateway = normalizeGatewayUrl(customGateway.value);
-    if (!nextGateway) {
-      gatewayError.value = 'Enter a valid public HTTPS gateway URL that ends with /ipfs/.';
-      return;
-    }
-    customGateway.value = nextGateway;
-    persistCustomGateway(nextGateway, window);
+    nextGateway = normalizedCustomGateway;
   } else {
     const selectedGateway = builtInGateways.find((gateway) => gateway.id === selectedGatewayId.value);
     nextGateway = selectedGateway ? gatewayUrl(selectedGateway) : gatewayUrl(builtInGateways[0]);
   }
 
+  captureStoredGatewayDrafts();
   emit('gateway-change', nextGateway);
   closeSettings();
 }
@@ -1031,16 +1143,13 @@ function clearGatewayCooldown(url) {
   gatewayCooldownUntilByUrl.value = nextCooldowns;
 }
 
-function persistLocalGateway() {
-  try {
-    const payload = {
-      host: localHost.value,
-      port: localPort.value,
-    };
-    localStorage.setItem(localStorageKey, JSON.stringify(payload));
-  } catch (_) {
-    // ignore storage errors
+function captureStoredGatewayDrafts() {
+  if (isDevMode) {
+    storedLocalHost.value = normalizeLocalGatewayHost(localHost.value);
+    storedLocalPort.value = normalizeLocalGatewayPort(localPort.value);
   }
+
+  storedCustomGateway.value = customGatewayPreview.value;
 }
 
 function persistLocalEnvironmentApi() {
@@ -1050,20 +1159,6 @@ function persistLocalEnvironmentApi() {
       port: localEnvironmentApiPort.value,
     };
     localStorage.setItem(localEnvironmentApiStorageKey, JSON.stringify(payload));
-  } catch (_) {
-    // ignore storage errors
-  }
-}
-
-function restoreLocalGateway() {
-  try {
-    const raw = localStorage.getItem(localStorageKey);
-    if (!raw) return;
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed.host === 'string' && typeof parsed.port === 'string') {
-      localHost.value = parsed.host;
-      localPort.value = parsed.port;
-    }
   } catch (_) {
     // ignore storage errors
   }
@@ -1150,7 +1245,9 @@ onMounted(() => {
   document.addEventListener('pointerdown', handleDocumentPointerDown);
   document.addEventListener('keydown', handleDocumentKeydown);
   if (isDevMode) {
-    restoreLocalGateway();
+    const storedLocalConfig = readStoredLocalGatewayConfig(window);
+    localHost.value = storedLocalConfig.host;
+    localPort.value = storedLocalConfig.port;
     restoreLocalEnvironmentApi();
     localEnvironmentCheckState.value = createIdleEnvironmentCheckState({
       target: {
@@ -1168,6 +1265,7 @@ onMounted(() => {
     customGateway.value = '';
     persistCustomGateway('', window);
   }
+  captureStoredGatewayDrafts();
   resetGatewayProbeStates();
 });
 
@@ -1571,6 +1669,15 @@ onBeforeUnmount(() => {
               <h4>Custom Gateway</h4>
               <p class="gateway-section-caption">Public HTTPS gateway only.</p>
             </div>
+            <button
+              type="button"
+              class="ghost-btn gateway-reset-btn"
+              data-testid="gateway-custom-reset-button"
+              :disabled="!canRestoreCustomGatewayDefaults"
+              @click="restoreCustomGatewayDefaults"
+            >
+              {{ t('header.actions.gateway.restoreDefaults') }}
+            </button>
           </div>
 
           <div class="custom-config active">
@@ -1601,6 +1708,15 @@ onBeforeUnmount(() => {
               <h4>Local Node Settings</h4>
               <p class="gateway-section-caption">Only shown when the local gateway is selected.</p>
             </div>
+            <button
+              type="button"
+              class="ghost-btn gateway-reset-btn"
+              data-testid="gateway-local-reset-button"
+              :disabled="!canRestoreLocalGatewayDefaults"
+              @click="restoreLocalGatewayDefaults"
+            >
+              {{ t('header.actions.gateway.restoreDefaults') }}
+            </button>
           </div>
 
           <div class="local-config">
@@ -1647,7 +1763,7 @@ onBeforeUnmount(() => {
           </div>
         </section>
 
-        <div v-if="gatewayError" class="gateway-error" role="status" aria-live="assertive">
+        <div v-if="gatewayError" class="gateway-error" role="status" aria-live="assertive" data-testid="gateway-error">
           {{ gatewayError }}
         </div>
       </div>
@@ -2571,6 +2687,14 @@ onBeforeUnmount(() => {
   color: var(--text-secondary);
   font-size: 0.82rem;
   line-height: 1.45;
+}
+
+.gateway-reset-btn {
+  min-width: auto;
+  min-height: 36px;
+  padding: 8px 12px;
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .gateway-list {

--- a/src/components/header_gateway_reset.spec.js
+++ b/src/components/header_gateway_reset.spec.js
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { parse } from '@vue/compiler-sfc';
+import { describe, expect, it } from 'vitest';
+
+function readDescriptor(fileUrl) {
+  const source = readFileSync(fileUrl, 'utf8');
+  return parse(source).descriptor;
+}
+
+function getStyleContent(descriptor) {
+  return descriptor.styles.map((style) => style.content).join('\n');
+}
+
+describe('Gateway reset controls', () => {
+  it('keeps reset actions independent and Apply-gated', () => {
+    const descriptor = readDescriptor(new URL('./Header.vue', import.meta.url));
+    const template = descriptor.template?.content || '';
+    const script = descriptor.scriptSetup?.content || '';
+    const style = getStyleContent(descriptor);
+
+    expect(template).toContain('data-testid="gateway-custom-reset-button"');
+    expect(template).toContain('data-testid="gateway-local-reset-button"');
+    expect(template).toContain("t('header.actions.gateway.restoreDefaults')");
+    expect(template).toContain('data-testid="gateway-error"');
+
+    expect(script).toContain('const hasPendingLocalGatewayReset = computed(');
+    expect(script).toContain('const hasPendingCustomGatewayReset = computed(');
+    expect(script).toContain('function restoreCustomGatewayDefaults() {');
+    expect(script).toContain('function restoreLocalGatewayDefaults() {');
+    expect(script).toContain('persistLocalGatewayConfig(');
+    expect(script).toContain('persistCustomGateway(normalizedCustomGateway, window);');
+    expect(script).toContain('Choose another gateway or enter a valid custom gateway before applying.');
+
+    expect(style).toContain('.gateway-reset-btn');
+  });
+});

--- a/src/i18n/messages/en.js
+++ b/src/i18n/messages/en.js
@@ -40,6 +40,7 @@ export default Object.freeze({
       gateway: {
         label: 'Gateway',
         ariaLabel: 'Switch gateway. Current gateway: {gateway}',
+        restoreDefaults: 'Restore defaults',
       },
       infoJson: {
         label: 'Drafts',

--- a/src/i18n/messages/zh-TW.js
+++ b/src/i18n/messages/zh-TW.js
@@ -40,6 +40,7 @@ export default Object.freeze({
       gateway: {
         label: '網關',
         ariaLabel: '切換網關，目前為 {gateway}',
+        restoreDefaults: '恢復預設值',
       },
       infoJson: {
         label: '素材草稿',

--- a/src/utils/gateway.js
+++ b/src/utils/gateway.js
@@ -1,5 +1,6 @@
 export const gatewayStorageKey = 'ipfs-hls-selected-gateway';
 export const customGatewayStorageKey = 'ipfs-hls-custom-gateway';
+export const localGatewayStorageKey = 'ipfs-hls-local-gateway';
 export const gatewayProbeTimeoutMs = 5000;
 export const gatewayRateLimitBackoffMs = 30 * 60 * 1000;
 export const gatewayProbeSegmentSampleCount = 3;
@@ -22,7 +23,9 @@ export const publicGatewayOptions = [
   },
 ];
 export const defaultPublicGateway = publicGatewayOptions[0].url;
-export const defaultLocalGateway = 'http://127.0.0.1:8080/ipfs/';
+export const defaultLocalGatewayHost = '127.0.0.1';
+export const defaultLocalGatewayPort = '8080';
+export const defaultLocalGateway = `http://${defaultLocalGatewayHost}:${defaultLocalGatewayPort}/ipfs/`;
 
 function resolveStorage(target) {
   if (target && typeof target.getItem === 'function') {
@@ -54,6 +57,71 @@ export function readStoredCustomGateway(target) {
 
 export function persistCustomGateway(gateway, target) {
   persistStoredValue(customGatewayStorageKey, gateway, target);
+}
+
+export function normalizeLocalGatewayHost(value) {
+  const normalized = String(value || '')
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/.*$/, '')
+    .replace(/:\d+$/, '');
+
+  return normalized || defaultLocalGatewayHost;
+}
+
+export function normalizeLocalGatewayPort(value) {
+  const digits = String(value || '')
+    .trim()
+    .replace(/[^0-9]/g, '');
+
+  return digits || defaultLocalGatewayPort;
+}
+
+export function readStoredLocalGatewayConfig(target) {
+  const storage = resolveStorage(target);
+  if (!storage) {
+    return {
+      host: defaultLocalGatewayHost,
+      port: defaultLocalGatewayPort,
+    };
+  }
+
+  try {
+    const raw = storage.getItem(localGatewayStorageKey);
+    if (!raw) {
+      return {
+        host: defaultLocalGatewayHost,
+        port: defaultLocalGatewayPort,
+      };
+    }
+
+    const parsed = JSON.parse(raw);
+    return {
+      host: normalizeLocalGatewayHost(parsed?.host),
+      port: normalizeLocalGatewayPort(parsed?.port),
+    };
+  } catch (_) {
+    return {
+      host: defaultLocalGatewayHost,
+      port: defaultLocalGatewayPort,
+    };
+  }
+}
+
+export function persistLocalGatewayConfig(config, target) {
+  const storage = resolveStorage(target);
+  if (!storage) return;
+
+  const payload = {
+    host: normalizeLocalGatewayHost(config?.host),
+    port: normalizeLocalGatewayPort(config?.port),
+  };
+
+  try {
+    storage.setItem(localGatewayStorageKey, JSON.stringify(payload));
+  } catch (_) {
+    // ignore storage errors
+  }
 }
 
 function readStoredValue(key, target) {

--- a/src/utils/gateway.spec.js
+++ b/src/utils/gateway.spec.js
@@ -3,6 +3,8 @@ import {
   buildGatewayAssetUrl,
   buildGatewayIndexUrl,
   customGatewayStorageKey,
+  defaultLocalGatewayHost,
+  defaultLocalGatewayPort,
   fetchGatewayVariantPlaylists,
   gatewayRateLimitBackoffMs,
   gatewayProbeSegmentSampleCount,
@@ -11,11 +13,16 @@ import {
   isLoopbackGatewayUrl,
   isLoopbackHostname,
   isPrivateHostname,
+  localGatewayStorageKey,
   normalizeGatewayUrl,
+  normalizeLocalGatewayHost,
+  normalizeLocalGatewayPort,
   persistCustomGateway,
   persistGateway,
+  persistLocalGatewayConfig,
   probeGatewayAvailability,
   readStoredCustomGateway,
+  readStoredLocalGatewayConfig,
   readStoredGateway,
   shouldAutoFallbackGateway,
 } from './gateway';
@@ -118,6 +125,51 @@ describe('custom gateway storage', () => {
 
     expect(storage.getItem(customGatewayStorageKey)).toBe('https://friend.example/ipfs/');
     expect(readStoredCustomGateway(storage)).toBe('https://friend.example/ipfs/');
+  });
+});
+
+describe('local gateway storage', () => {
+  it('returns default localhost settings when storage is missing', () => {
+    expect(readStoredLocalGatewayConfig(null)).toEqual({
+      host: defaultLocalGatewayHost,
+      port: defaultLocalGatewayPort,
+    });
+  });
+
+  it('stores and reads normalized local gateway settings', () => {
+    const storage = createStorage();
+
+    persistLocalGatewayConfig({ host: ' http://192.168.1.7/path ', port: '80abc80' }, storage);
+
+    expect(JSON.parse(storage.getItem(localGatewayStorageKey))).toEqual({
+      host: '192.168.1.7',
+      port: '8080',
+    });
+    expect(readStoredLocalGatewayConfig(storage)).toEqual({
+      host: '192.168.1.7',
+      port: '8080',
+    });
+  });
+});
+
+describe('normalizeLocalGatewayHost', () => {
+  it('normalizes protocol, path, and port segments', () => {
+    expect(normalizeLocalGatewayHost('http://localhost:8080/ipfs/')).toBe('localhost');
+    expect(normalizeLocalGatewayHost(' 192.168.1.5/path ')).toBe('192.168.1.5');
+  });
+
+  it('falls back to the default host when the value is blank', () => {
+    expect(normalizeLocalGatewayHost('   ')).toBe(defaultLocalGatewayHost);
+  });
+});
+
+describe('normalizeLocalGatewayPort', () => {
+  it('keeps digits only', () => {
+    expect(normalizeLocalGatewayPort('80abc80')).toBe('8080');
+  });
+
+  it('falls back to the default port when the value is blank', () => {
+    expect(normalizeLocalGatewayPort('   ')).toBe(defaultLocalGatewayPort);
   });
 });
 


### PR DESCRIPTION
## Why
- #54 需要讓 Custom Gateway 與 Local Node 各自支援恢復預設值
- 恢復預設值只能先更新設定草稿，必須等到按下 Apply 才正式生效
- 當選中的 Custom Gateway 被恢復成空白時，Apply 應原子性阻擋送出

## What
- 在 gateway dialog 新增 Custom Gateway / Local Node 的恢復預設值按鈕與待套用摘要
- 抽出 local gateway storage helper，讓 reset 變更能在選擇 public gateway 時一起於 Apply 寫入
- 補上空白 custom gateway 的 Apply 驗證、i18n 文案與單元 / E2E 測試

## Validation
- `npm test`
- `npm run build`
- `CI=1 npm run test:e2e`

Closes #54
